### PR TITLE
Rename mvec_node to mvec ros2 for clarity

### DIFF
--- a/mvec/mvec_ros2/CMakeLists.txt
+++ b/mvec/mvec_ros2/CMakeLists.txt
@@ -1,3 +1,16 @@
+# Copyright (c) 2025-present Polymath Robotics, Inc. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 cmake_minimum_required(VERSION 3.8)
 project(mvec_ros2)
 
@@ -79,4 +92,3 @@ install(EXPORT ${PROJECT_NAME}_TARGETS
 # Export
 ament_export_targets(${PROJECT_NAME}_TARGETS HAS_LIBRARY_TARGET)
 ament_package()
-

--- a/mvec/mvec_ros2/CMakeLists.txt
+++ b/mvec/mvec_ros2/CMakeLists.txt
@@ -1,19 +1,5 @@
-# Copyright (c) 2025-present Polymath Robotics, Inc. All rights reserved
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 cmake_minimum_required(VERSION 3.8)
-project(mvec_node)
+project(mvec_ros2)
 
 # Project-wide language standards
 if(NOT CMAKE_CXX_STANDARD)
@@ -46,17 +32,17 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${ASAN_FLAGS}")
 endif()
 
-# Primary library
-add_library(mvec_node SHARED
+# Primary component library (renamed to avoid conflict with executable)
+add_library(mvec_ros2 SHARED
   src/mvec_node.cpp
 )
-target_include_directories(mvec_node PUBLIC
+target_include_directories(mvec_ros2 PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
-target_compile_definitions(mvec_node PRIVATE "MVEC_NODE_BUILDING_LIBRARY")
+target_compile_definitions(mvec_ros2 PRIVATE "MVEC_NODE_BUILDING_LIBRARY")
 
-target_link_libraries(mvec_node PUBLIC
+target_link_libraries(mvec_ros2 PUBLIC
   rclcpp::rclcpp
   rclcpp_lifecycle::rclcpp_lifecycle
   rclcpp_components::component
@@ -67,24 +53,24 @@ target_link_libraries(mvec_node PUBLIC
   socketcan_adapter::socketcan_adapter
 )
 
-# Generate composable node executable
-rclcpp_components_register_node(mvec_node
+# Generate composable node executable (renamed from mvec_bridge to mvec_node)
+rclcpp_components_register_node(mvec_ros2
   PLUGIN "polymath::mvec::MvecNode"
-  EXECUTABLE mvec_bridge)
+  EXECUTABLE mvec_node)
 
 # Installs
 install(DIRECTORY include/ DESTINATION include)
 install(DIRECTORY config/ DESTINATION share/${PROJECT_NAME}/config)
 install(DIRECTORY launch/ DESTINATION share/${PROJECT_NAME}/launch)
 
-install(TARGETS mvec_node
+install(TARGETS mvec_ros2
   EXPORT ${PROJECT_NAME}_TARGETS
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
 )
 
-install(TARGETS mvec_bridge DESTINATION lib/${PROJECT_NAME})
+install(TARGETS mvec_node DESTINATION lib/${PROJECT_NAME})
 install(EXPORT ${PROJECT_NAME}_TARGETS
   NAMESPACE ${PROJECT_NAME}::
   DESTINATION share/${PROJECT_NAME}/cmake
@@ -93,3 +79,4 @@ install(EXPORT ${PROJECT_NAME}_TARGETS
 # Export
 ament_export_targets(${PROJECT_NAME}_TARGETS HAS_LIBRARY_TARGET)
 ament_package()
+

--- a/mvec/mvec_ros2/CMakeLists.txt
+++ b/mvec/mvec_ros2/CMakeLists.txt
@@ -25,16 +25,8 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_link_options(-Wl,-no-undefined)
 endif()
 
-# Dependencies
-find_package(ament_cmake REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(rclcpp_lifecycle REQUIRED)
-find_package(rclcpp_components REQUIRED)
-find_package(diagnostic_msgs REQUIRED)
-find_package(magic_enum REQUIRED)
-find_package(mvec_msgs REQUIRED)
-find_package(mvec_lib REQUIRED)
-find_package(socketcan_adapter REQUIRED)
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   message(STATUS "Enabling AddressSanitizer (ASAN) for Debug build")
@@ -45,16 +37,16 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${ASAN_FLAGS}")
 endif()
 
-add_library(mvec_ros2 SHARED
+add_library(${PROJECT_NAME} SHARED
   src/mvec_node.cpp
 )
-target_include_directories(mvec_ros2 PUBLIC
+target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
-target_compile_definitions(mvec_ros2 PRIVATE "MVEC_NODE_BUILDING_LIBRARY")
+target_compile_definitions(${PROJECT_NAME} PRIVATE "MVEC_NODE_BUILDING_LIBRARY")
 
-target_link_libraries(mvec_ros2 PUBLIC
+target_link_libraries(${PROJECT_NAME} PUBLIC
   rclcpp::rclcpp
   rclcpp_lifecycle::rclcpp_lifecycle
   rclcpp_components::component
@@ -65,23 +57,22 @@ target_link_libraries(mvec_ros2 PUBLIC
   socketcan_adapter::socketcan_adapter
 )
 
-rclcpp_components_register_node(mvec_ros2
+rclcpp_components_register_node(${PROJECT_NAME}
   PLUGIN "polymath::mvec::MvecNode"
-  EXECUTABLE mvec_node)
+  EXECUTABLE ${PROJECT_NAME}_node)
 
 # Installs
 install(DIRECTORY include/ DESTINATION include)
 install(DIRECTORY config/ DESTINATION share/${PROJECT_NAME}/config)
 install(DIRECTORY launch/ DESTINATION share/${PROJECT_NAME}/launch)
 
-install(TARGETS mvec_ros2
+install(TARGETS ${PROJECT_NAME}
   EXPORT ${PROJECT_NAME}_TARGETS
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
 )
 
-install(TARGETS mvec_node DESTINATION lib/${PROJECT_NAME})
 install(EXPORT ${PROJECT_NAME}_TARGETS
   NAMESPACE ${PROJECT_NAME}::
   DESTINATION share/${PROJECT_NAME}/cmake

--- a/mvec/mvec_ros2/CMakeLists.txt
+++ b/mvec/mvec_ros2/CMakeLists.txt
@@ -45,7 +45,6 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${ASAN_FLAGS}")
 endif()
 
-# Primary component library (renamed to avoid conflict with executable)
 add_library(mvec_ros2 SHARED
   src/mvec_node.cpp
 )
@@ -66,7 +65,6 @@ target_link_libraries(mvec_ros2 PUBLIC
   socketcan_adapter::socketcan_adapter
 )
 
-# Generate composable node executable
 rclcpp_components_register_node(mvec_ros2
   PLUGIN "polymath::mvec::MvecNode"
   EXECUTABLE mvec_node)
@@ -89,6 +87,5 @@ install(EXPORT ${PROJECT_NAME}_TARGETS
   DESTINATION share/${PROJECT_NAME}/cmake
 )
 
-# Export
 ament_export_targets(${PROJECT_NAME}_TARGETS HAS_LIBRARY_TARGET)
 ament_package()

--- a/mvec/mvec_ros2/CMakeLists.txt
+++ b/mvec/mvec_ros2/CMakeLists.txt
@@ -66,7 +66,7 @@ target_link_libraries(mvec_ros2 PUBLIC
   socketcan_adapter::socketcan_adapter
 )
 
-# Generate composable node executable (renamed from mvec_bridge to mvec_node)
+# Generate composable node executable
 rclcpp_components_register_node(mvec_ros2
   PLUGIN "polymath::mvec::MvecNode"
   EXECUTABLE mvec_node)

--- a/mvec/mvec_ros2/README.md
+++ b/mvec/mvec_ros2/README.md
@@ -34,4 +34,3 @@ mvec_node:
     preset_0_name: "enable"
     preset_0_relays: ["0:1", "2:1", "4:0"]
 ```
-

--- a/mvec/mvec_ros2/README.md
+++ b/mvec/mvec_ros2/README.md
@@ -1,4 +1,4 @@
-# MVEC Node
+# MVEC ROS 2
 
 ROS2 composable lifecycle node for MVEC relay control system.
 
@@ -7,7 +7,7 @@ ROS2 composable lifecycle node for MVEC relay control system.
 ### Launch
 
 ```bash
-ros2 launch mvec_node mvec_bridge_launch.py
+ros2 launch mvec_ros2 mvec_bridge_launch.py
 ```
 
 ### Parameters
@@ -34,3 +34,4 @@ mvec_node:
     preset_0_name: "enable"
     preset_0_relays: ["0:1", "2:1", "4:0"]
 ```
+

--- a/mvec/mvec_ros2/config/relay_presets.yaml
+++ b/mvec/mvec_ros2/config/relay_presets.yaml
@@ -10,4 +10,3 @@ mvec_node:
       - 10:0 # relay_id:relay_state
       - 8:1
       - 1:0
-

--- a/mvec/mvec_ros2/config/relay_presets.yaml
+++ b/mvec/mvec_ros2/config/relay_presets.yaml
@@ -10,3 +10,4 @@ mvec_node:
       - 10:0 # relay_id:relay_state
       - 8:1
       - 1:0
+

--- a/mvec/mvec_ros2/include/mvec_ros2/mvec_node.hpp
+++ b/mvec/mvec_ros2/include/mvec_ros2/mvec_node.hpp
@@ -140,3 +140,4 @@ private:
 RCLCPP_COMPONENTS_REGISTER_NODE(polymath::mvec::MvecNode)
 
 #endif  // MVEC_NODE__MVEC_NODE_HPP_
+

--- a/mvec/mvec_ros2/include/mvec_ros2/mvec_node.hpp
+++ b/mvec/mvec_ros2/include/mvec_ros2/mvec_node.hpp
@@ -140,4 +140,3 @@ private:
 RCLCPP_COMPONENTS_REGISTER_NODE(polymath::mvec::MvecNode)
 
 #endif  // MVEC_NODE__MVEC_NODE_HPP_
-

--- a/mvec/mvec_ros2/launch/mvec_bridge_launch.py
+++ b/mvec/mvec_ros2/launch/mvec_bridge_launch.py
@@ -72,8 +72,8 @@ def generate_launch_description():
     # Create the MVEC node (executable renamed from mvec_bridge to mvec_node)
     mvec_node = LifecycleNode(
         package="mvec_ros2",
-        executable="mvec_node",
-        name="mvec_node",
+        executable="mvec_ros2_node",
+        name="mvec_ros2_node",
         namespace="",
         parameters=[
             LaunchConfiguration("config_file"),

--- a/mvec/mvec_ros2/launch/mvec_bridge_launch.py
+++ b/mvec/mvec_ros2/launch/mvec_bridge_launch.py
@@ -29,7 +29,7 @@ from launch_ros.substitutions import FindPackageShare
 def generate_launch_description():
     # Default config file path using find-pkg-share
     default_config_file = PathJoinSubstitution(
-        [FindPackageShare("mvec_node"), "config", "relay_presets.yaml"]
+        [FindPackageShare("mvec_ros2"), "config", "relay_presets.yaml"]
     )
 
     # Define launch arguments
@@ -69,11 +69,11 @@ def generate_launch_description():
         description="Automatically activate the lifecycle node after configuration",
     )
 
-    # Create the MVEC bridge node
-    mvec_bridge_node = LifecycleNode(
-        package="mvec_node",
-        executable="mvec_bridge",
-        name="mvec_bridge",
+    # Create the MVEC node (executable renamed from mvec_bridge to mvec_node)
+    mvec_node = LifecycleNode(
+        package="mvec_ros2",
+        executable="mvec_node",
+        name="mvec_node",
         namespace="",
         parameters=[
             LaunchConfiguration("config_file"),
@@ -87,13 +87,13 @@ def generate_launch_description():
     )
 
     # Event handler to automatically configure the node
-    mvec_bridge_configure_event_handler = RegisterEventHandler(
+    mvec_configure_event_handler = RegisterEventHandler(
         event_handler=OnProcessStart(
-            target_action=mvec_bridge_node,
+            target_action=mvec_node,
             on_start=[
                 EmitEvent(
                     event=ChangeState(
-                        lifecycle_node_matcher=matches_action(mvec_bridge_node),
+                        lifecycle_node_matcher=matches_action(mvec_node),
                         transition_id=Transition.TRANSITION_CONFIGURE,
                     ),
                 ),
@@ -103,15 +103,15 @@ def generate_launch_description():
     )
 
     # Event handler to automatically activate the node after configuration
-    mvec_bridge_activate_event_handler = RegisterEventHandler(
+    mvec_activate_event_handler = RegisterEventHandler(
         event_handler=OnStateTransition(
-            target_lifecycle_node=mvec_bridge_node,
+            target_lifecycle_node=mvec_node,
             start_state="configuring",
             goal_state="inactive",
             entities=[
                 EmitEvent(
                     event=ChangeState(
-                        lifecycle_node_matcher=matches_action(mvec_bridge_node),
+                        lifecycle_node_matcher=matches_action(mvec_node),
                         transition_id=Transition.TRANSITION_ACTIVATE,
                     ),
                 ),
@@ -128,8 +128,9 @@ def generate_launch_description():
             timeout_ms_arg,
             auto_configure_arg,
             auto_activate_arg,
-            mvec_bridge_node,
-            mvec_bridge_configure_event_handler,
-            mvec_bridge_activate_event_handler,
+            mvec_node,
+            mvec_configure_event_handler,
+            mvec_activate_event_handler,
         ]
     )
+

--- a/mvec/mvec_ros2/launch/mvec_bridge_launch.py
+++ b/mvec/mvec_ros2/launch/mvec_bridge_launch.py
@@ -133,4 +133,3 @@ def generate_launch_description():
             mvec_activate_event_handler,
         ]
     )
-

--- a/mvec/mvec_ros2/package.xml
+++ b/mvec/mvec_ros2/package.xml
@@ -24,4 +24,3 @@
     <build_type>ament_cmake</build_type>
   </export>
 </package>
-

--- a/mvec/mvec_ros2/package.xml
+++ b/mvec/mvec_ros2/package.xml
@@ -8,6 +8,7 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>

--- a/mvec/mvec_ros2/package.xml
+++ b/mvec/mvec_ros2/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>mvec_node</name>
+  <name>mvec_ros2</name>
   <version>0.0.0</version>
   <description>ROS2 node for MVEC relay control system with diagnostics publishing and relay control service</description>
   <maintainer email="engineering@polymathrobotics.com">Polymath Robotics Engineering</maintainer>
@@ -24,3 +24,4 @@
     <build_type>ament_cmake</build_type>
   </export>
 </package>
+

--- a/mvec/mvec_ros2/src/mvec_node.cpp
+++ b/mvec/mvec_ros2/src/mvec_node.cpp
@@ -331,7 +331,7 @@ void MvecNode::setMultiRelayCallback(
   const std::shared_ptr<mvec_msgs::srv::SetMultiRelay::Request> request,
   std::shared_ptr<mvec_msgs::srv::SetMultiRelay::Response> response)
 {
-  RCLCPP_INFO(get_logger(), "Setting multiple relays (%zu)", request->relays.size());
+  RCLCPP_INFO(get_logger(), "Setting %zu relays", request->relays.size());
 
   auto result = set_multi_relay(request->relays);
   if (result.has_value()) {
@@ -349,16 +349,17 @@ void MvecNode::triggerPresetCallback(
   const std::shared_ptr<mvec_msgs::srv::TriggerPreset::Request> request,
   std::shared_ptr<mvec_msgs::srv::TriggerPreset::Response> response)
 {
-  RCLCPP_INFO(get_logger(), "Triggering preset '%s'", request->name.c_str());
+  RCLCPP_INFO(get_logger(), "Triggering preset: %s", request->name.c_str());
 
   // Find the preset by name
-  auto it = std::find_if(presets_.begin(), presets_.end(), [&](const mvec_msgs::msg::Preset & preset) {
+  auto it = std::find_if(presets_.begin(), presets_.end(), [&request](const mvec_msgs::msg::Preset & preset) {
     return preset.name == request->name;
   });
 
   if (it == presets_.end()) {
     response->success = false;
-    response->message = "Preset not found: '" + request->name + "'";
+    response->message = "Preset not found: " + request->name;
+    RCLCPP_WARN(get_logger(), "%s", response->message.c_str());
     return;
   }
 
@@ -366,6 +367,7 @@ void MvecNode::triggerPresetCallback(
   if (result.has_value()) {
     response->success = false;
     response->message = result.value();
+    response->message = "Failed to trigger preset '" + request->name + "': " + result.value();
   } else {
     response->success = true;
     response->message = "Preset '" + request->name + "' triggered successfully";

--- a/mvec/mvec_ros2/src/mvec_node.cpp
+++ b/mvec/mvec_ros2/src/mvec_node.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "mvec_node/mvec_node.hpp"
+#include "mvec_ros2/mvec_node.hpp"
 
 #include <algorithm>
 #include <chrono>
@@ -331,11 +331,11 @@ void MvecNode::setMultiRelayCallback(
   const std::shared_ptr<mvec_msgs::srv::SetMultiRelay::Request> request,
   std::shared_ptr<mvec_msgs::srv::SetMultiRelay::Response> response)
 {
-  RCLCPP_INFO(get_logger(), "Setting %zu relays", request->relays.size());
+  RCLCPP_INFO(get_logger(), "Setting multiple relays (%zu)", request->relays.size());
 
   auto result = set_multi_relay(request->relays);
   if (result.has_value()) {
-    // Error occurred
+    // Error
     response->success = false;
     response->message = result.value();
   } else {
@@ -349,27 +349,24 @@ void MvecNode::triggerPresetCallback(
   const std::shared_ptr<mvec_msgs::srv::TriggerPreset::Request> request,
   std::shared_ptr<mvec_msgs::srv::TriggerPreset::Response> response)
 {
-  RCLCPP_INFO(get_logger(), "Triggering preset: %s", request->name.c_str());
+  RCLCPP_INFO(get_logger(), "Triggering preset '%s'", request->name.c_str());
 
   // Find the preset by name
-  auto it = std::find_if(presets_.begin(), presets_.end(), [&request](const mvec_msgs::msg::Preset & preset) {
+  auto it = std::find_if(presets_.begin(), presets_.end(), [&](const mvec_msgs::msg::Preset & preset) {
     return preset.name == request->name;
   });
 
   if (it == presets_.end()) {
     response->success = false;
-    response->message = "Preset not found: " + request->name;
-    RCLCPP_WARN(get_logger(), "%s", response->message.c_str());
+    response->message = "Preset not found: '" + request->name + "'";
     return;
   }
 
   auto result = set_multi_relay(it->relays);
   if (result.has_value()) {
-    // Error occurred
     response->success = false;
-    response->message = "Failed to trigger preset '" + request->name + "': " + result.value();
+    response->message = result.value();
   } else {
-    // Success
     response->success = true;
     response->message = "Preset '" + request->name + "' triggered successfully";
   }
@@ -561,3 +558,4 @@ void MvecNode::parsePresetParams()
 }
 
 }  // namespace polymath::mvec
+

--- a/mvec/mvec_ros2/src/mvec_node.cpp
+++ b/mvec/mvec_ros2/src/mvec_node.cpp
@@ -558,4 +558,3 @@ void MvecNode::parsePresetParams()
 }
 
 }  // namespace polymath::mvec
-

--- a/mvec/mvec_ros2/src/mvec_node.cpp
+++ b/mvec/mvec_ros2/src/mvec_node.cpp
@@ -366,7 +366,6 @@ void MvecNode::triggerPresetCallback(
   auto result = set_multi_relay(it->relays);
   if (result.has_value()) {
     response->success = false;
-    response->message = result.value();
     response->message = "Failed to trigger preset '" + request->name + "': " + result.value();
   } else {
     response->success = true;


### PR DESCRIPTION
mvec_bridge was a confusing name and caused issues when referring to the node in config files and launch files as it was unintuitive. Renaming the library to mvec_ros2 and the node to mvec_node clarifies the executable and specific implementation.