### PR TITLE
added jazzy, kilted, and rolling CI and support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,12 @@ jobs:
         include:
           - ros: humble
             ubuntu: jammy
-          # TODO(Zeerek): Enable once socketcan adapter supports them
-          # - ros: jazzy
-          #   ubuntu: noble
-          # - ros: rolling
-          #   ubuntu: noble
+          - ros: jazzy
+            ubuntu: noble
+          - ros: kilted
+            ubuntu: noble
+          - ros: rolling
+            ubuntu: noble
     name: ROS 2 ${{ matrix.ros }}
     container:
       image: ghcr.io/ros-tooling/setup-ros-docker/setup-ros-docker-ubuntu-${{ matrix.ubuntu }}:latest

--- a/mvec/mvec_lib/CMakeLists.txt
+++ b/mvec/mvec_lib/CMakeLists.txt
@@ -81,6 +81,7 @@ ament_export_dependencies(
 if(BUILD_TESTING)
   find_package(ament_cmake_auto REQUIRED)
   ament_auto_find_test_dependencies()
+  find_package(Catch2 REQUIRED)
 
   add_executable(relay_tests
     test/mvec_relay.cpp

--- a/mvec/mvec_lib/CMakeLists.txt
+++ b/mvec/mvec_lib/CMakeLists.txt
@@ -25,11 +25,8 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_link_options("-Wl,--no-undefined")
 endif()
 
-find_package(ament_cmake REQUIRED)
-find_package(socketcan_adapter REQUIRED)
-
-# socketcan adapter's improperly configured dependencies
-# TODO (Zeerek): Remove when socketcan adapter's dependencies are cleaned up
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
 add_library(
   ${PROJECT_NAME} SHARED
@@ -79,7 +76,6 @@ ament_export_dependencies(
 )
 
 if(BUILD_TESTING)
-  find_package(ament_cmake_auto REQUIRED)
   ament_auto_find_test_dependencies()
   find_package(Catch2 REQUIRED)
 

--- a/mvec/mvec_lib/CMakeLists.txt
+++ b/mvec/mvec_lib/CMakeLists.txt
@@ -79,8 +79,8 @@ ament_export_dependencies(
 )
 
 if(BUILD_TESTING)
-  find_package(Catch2 2 REQUIRED)
-  include(Catch)
+  find_package(ament_cmake_auto REQUIRED)
+  ament_auto_find_test_dependencies()
 
   add_executable(relay_tests
     test/mvec_relay.cpp
@@ -88,7 +88,15 @@ if(BUILD_TESTING)
   target_link_libraries(relay_tests
     PRIVATE ${PROJECT_NAME} Catch2::Catch2WithMain
   )
-  catch_discover_tests(relay_tests)
+  ament_add_test(
+    relay_tests
+    GENERATE_RESULT_FOR_RETURN_CODE_ZERO
+    COMMAND "$<TARGET_FILE:relay_tests>"
+      -r junit -s
+      -o test_results/${PROJECT_NAME}/relay_tests_output.xml
+    ENV CATCH_CONFIG_CONSOLE_WIDTH=120
+    WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+  )
 
   add_executable(status_messages_tests
     test/status_messages.cpp
@@ -96,7 +104,15 @@ if(BUILD_TESTING)
   target_link_libraries(status_messages_tests
     PRIVATE ${PROJECT_NAME} Catch2::Catch2WithMain
   )
-  catch_discover_tests(status_messages_tests)
+  ament_add_test(
+    status_messages_tests
+    GENERATE_RESULT_FOR_RETURN_CODE_ZERO
+    COMMAND "$<TARGET_FILE:status_messages_tests>"
+      -r junit -s
+      -o test_results/${PROJECT_NAME}/status_messages_tests_output.xml
+    ENV CATCH_CONFIG_CONSOLE_WIDTH=120
+    WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+  )
 
   add_executable(status_enums_tests
     test/status_enums.cpp
@@ -104,7 +120,15 @@ if(BUILD_TESTING)
   target_link_libraries(status_enums_tests
     PRIVATE ${PROJECT_NAME} Catch2::Catch2WithMain
   )
-  catch_discover_tests(status_enums_tests)
+  ament_add_test(
+    status_enums_tests
+    GENERATE_RESULT_FOR_RETURN_CODE_ZERO
+    COMMAND "$<TARGET_FILE:status_enums_tests>"
+      -r junit -s
+      -o test_results/${PROJECT_NAME}/status_enums_tests_output.xml
+    ENV CATCH_CONFIG_CONSOLE_WIDTH=120
+    WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+  )
 
   # Only build hardware tests if CAN_AVAILABLE is set in the environment
   if(DEFINED ENV{CAN_AVAILABLE})
@@ -114,7 +138,15 @@ if(BUILD_TESTING)
     target_link_libraries(socketcan_hardware_tests
       PRIVATE ${PROJECT_NAME} Catch2::Catch2WithMain
     )
-    catch_discover_tests(socketcan_hardware_tests)
+    ament_add_test(
+      socketcan_hardware_tests
+      GENERATE_RESULT_FOR_RETURN_CODE_ZERO
+      COMMAND "$<TARGET_FILE:socketcan_hardware_tests>"
+        -r junit -s
+        -o test_results/${PROJECT_NAME}/socketcan_hardware_tests_output.xml
+      ENV CATCH_CONFIG_CONSOLE_WIDTH=120
+      WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+    )
     message(STATUS "CAN_AVAILABLE set - including hardware tests")
   else()
     message(STATUS "CAN_AVAILABLE not set - skipping hardware tests (set CAN_AVAILABLE=1 to enable)")

--- a/mvec/mvec_lib/package.xml
+++ b/mvec/mvec_lib/package.xml
@@ -8,9 +8,12 @@
   <license>Apache-2.0</license>
   <author email="zeerekahmad@hotmail.com">Zeerek Ahmad</author>
 
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <depend>socketcan_adapter</depend>
 
   <test_depend>ament_cmake_test</test_depend>
+  <test_depend>catch2</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/mvec/mvec_lib/test/mvec_relay.cpp
+++ b/mvec/mvec_lib/test/mvec_relay.cpp
@@ -17,7 +17,16 @@
 #include <memory>
 #include <vector>
 
-#include <catch2/catch.hpp>
+#if __has_include(<catch2/catch_all.hpp>)
+  #include <catch2/catch_all.hpp>
+  #include <catch2/catch_approx.hpp>
+using Catch::Approx;
+#elif __has_include(<catch2/catch.hpp>)
+  #include <catch2/catch.hpp>
+#else
+  #error "Catch2 headers not found. Please install Catch2 (v2 or v3)."
+#endif
+
 
 #include "mvec_lib/core/mvec_constants.hpp"
 #include "socketcan_adapter/can_frame.hpp"

--- a/mvec/mvec_lib/test/mvec_relay.cpp
+++ b/mvec/mvec_lib/test/mvec_relay.cpp
@@ -19,14 +19,11 @@
 
 #if __has_include(<catch2/catch_all.hpp>)
   #include <catch2/catch_all.hpp>
-  #include <catch2/catch_approx.hpp>
-using Catch::Approx;
 #elif __has_include(<catch2/catch.hpp>)
   #include <catch2/catch.hpp>
 #else
   #error "Catch2 headers not found. Please install Catch2 (v2 or v3)."
 #endif
-
 
 #include "mvec_lib/core/mvec_constants.hpp"
 #include "socketcan_adapter/can_frame.hpp"

--- a/mvec/mvec_lib/test/mvec_socketcan_hardware.cpp
+++ b/mvec/mvec_lib/test/mvec_socketcan_hardware.cpp
@@ -21,7 +21,15 @@
 #include <memory>
 #include <thread>
 
-#include <catch2/catch.hpp>
+#if __has_include(<catch2/catch_all.hpp>)
+  #include <catch2/catch_all.hpp>
+  #include <catch2/catch_approx.hpp>
+using Catch::Approx;
+#elif __has_include(<catch2/catch.hpp>)
+  #include <catch2/catch.hpp>
+#else
+  #error "Catch2 headers not found. Please install Catch2 (v2 or v3)."
+#endif
 
 #include "mvec_lib/mvec_relay_socketcan.hpp"
 #include "socketcan_adapter/socketcan_adapter.hpp"

--- a/mvec/mvec_lib/test/mvec_socketcan_hardware.cpp
+++ b/mvec/mvec_lib/test/mvec_socketcan_hardware.cpp
@@ -23,8 +23,6 @@
 
 #if __has_include(<catch2/catch_all.hpp>)
   #include <catch2/catch_all.hpp>
-  #include <catch2/catch_approx.hpp>
-using Catch::Approx;
 #elif __has_include(<catch2/catch.hpp>)
   #include <catch2/catch.hpp>
 #else

--- a/mvec/mvec_lib/test/status_enums.cpp
+++ b/mvec/mvec_lib/test/status_enums.cpp
@@ -14,7 +14,15 @@
 
 #include <vector>
 
-#include <catch2/catch.hpp>
+#if __has_include(<catch2/catch_all.hpp>)
+  #include <catch2/catch_all.hpp>
+  #include <catch2/catch_approx.hpp>
+using Catch::Approx;
+#elif __has_include(<catch2/catch.hpp>)
+  #include <catch2/catch.hpp>
+#else
+  #error "Catch2 headers not found. Please install Catch2 (v2 or v3)."
+#endif
 
 #include "mvec_lib/core/mvec_constants.hpp"
 #include "mvec_lib/status_messages/mvec_error_status_message.hpp"

--- a/mvec/mvec_lib/test/status_enums.cpp
+++ b/mvec/mvec_lib/test/status_enums.cpp
@@ -16,8 +16,6 @@
 
 #if __has_include(<catch2/catch_all.hpp>)
   #include <catch2/catch_all.hpp>
-  #include <catch2/catch_approx.hpp>
-using Catch::Approx;
 #elif __has_include(<catch2/catch.hpp>)
   #include <catch2/catch.hpp>
 #else

--- a/mvec/mvec_lib/test/status_messages.cpp
+++ b/mvec/mvec_lib/test/status_messages.cpp
@@ -14,7 +14,15 @@
 
 #include <vector>
 
-#include <catch2/catch.hpp>
+#if __has_include(<catch2/catch_all.hpp>)
+  #include <catch2/catch_all.hpp>
+  #include <catch2/catch_approx.hpp>
+using Catch::Approx;
+#elif __has_include(<catch2/catch.hpp>)
+  #include <catch2/catch.hpp>
+#else
+  #error "Catch2 headers not found. Please install Catch2 (v2 or v3)."
+#endif
 
 #include "mvec_lib/core/mvec_constants.hpp"
 #include "mvec_lib/status_messages/mvec_error_status_message.hpp"

--- a/mvec/mvec_lib/test/status_messages.cpp
+++ b/mvec/mvec_lib/test/status_messages.cpp
@@ -16,8 +16,6 @@
 
 #if __has_include(<catch2/catch_all.hpp>)
   #include <catch2/catch_all.hpp>
-  #include <catch2/catch_approx.hpp>
-using Catch::Approx;
 #elif __has_include(<catch2/catch.hpp>)
   #include <catch2/catch.hpp>
 #else

--- a/mvec/mvec_msgs/CMakeLists.txt
+++ b/mvec/mvec_msgs/CMakeLists.txt
@@ -15,10 +15,8 @@
 cmake_minimum_required(VERSION 3.8)
 project(mvec_msgs)
 
-find_package(ament_cmake REQUIRED)
-find_package(rosidl_default_generators REQUIRED)
-find_package(builtin_interfaces REQUIRED)
-find_package(std_msgs REQUIRED)
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
 set(msg_files
   "msg/Relay.msg"

--- a/mvec/mvec_msgs/package.xml
+++ b/mvec/mvec_msgs/package.xml
@@ -8,8 +8,11 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <depend>rosidl_default_generators</depend>
+  <depend>builtin_interfaces</depend>
+  <depend>std_msgs</depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
 

--- a/mvec/mvec_ros2/src/mvec_node.cpp
+++ b/mvec/mvec_ros2/src/mvec_node.cpp
@@ -23,7 +23,13 @@
 #include <utility>
 #include <vector>
 
-#include <magic_enum.hpp>
+#if __has_include(<magic_enum/magic_enum.hpp>)
+  #include <magic_enum/magic_enum.hpp>
+#elif __has_include(<magic_enum.hpp>)
+  #include <magic_enum.hpp>
+#else
+  #error "magic_enum headers not found. Please install magic_enum."
+#endif
 
 #include "mvec_lib/core/mvec_constants.hpp"
 

--- a/sygnal_can_interface/sygnal_can_interface_lib/CMakeLists.txt
+++ b/sygnal_can_interface/sygnal_can_interface_lib/CMakeLists.txt
@@ -24,9 +24,8 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_link_options("-Wl,--no-undefined")
 endif()
 
-find_package(ament_cmake REQUIRED)
-find_package(socketcan_adapter REQUIRED)
-find_package(sygnal_dbc REQUIRED)
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
 add_library(
   ${PROJECT_NAME} SHARED
@@ -42,10 +41,10 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 )
 
 target_link_libraries(${PROJECT_NAME}
-  PUBLIC socketcan_adapter::socketcan_adapter
+  PUBLIC
+    socketcan_adapter::socketcan_adapter
+    sygnal_dbc::sygnal_dbc
 )
-
-ament_target_dependencies(${PROJECT_NAME} PUBLIC sygnal_dbc)
 
 install(
   DIRECTORY include/
@@ -74,7 +73,6 @@ ament_export_dependencies(
 )
 
 if(BUILD_TESTING)
-  find_package(ament_cmake_auto REQUIRED)
   ament_auto_find_test_dependencies()
   find_package(Catch2 REQUIRED)
 

--- a/sygnal_can_interface/sygnal_can_interface_lib/CMakeLists.txt
+++ b/sygnal_can_interface/sygnal_can_interface_lib/CMakeLists.txt
@@ -76,6 +76,7 @@ ament_export_dependencies(
 if(BUILD_TESTING)
   find_package(ament_cmake_auto REQUIRED)
   ament_auto_find_test_dependencies()
+  find_package(Catch2 REQUIRED)
 
   add_executable(sygnal_mcm_interface_tests
     test/sygnal_mcm_interface_test.cpp

--- a/sygnal_can_interface/sygnal_can_interface_lib/CMakeLists.txt
+++ b/sygnal_can_interface/sygnal_can_interface_lib/CMakeLists.txt
@@ -74,8 +74,8 @@ ament_export_dependencies(
 )
 
 if(BUILD_TESTING)
-  find_package(Catch2 2 REQUIRED)
-  include(Catch)
+  find_package(ament_cmake_auto REQUIRED)
+  ament_auto_find_test_dependencies()
 
   add_executable(sygnal_mcm_interface_tests
     test/sygnal_mcm_interface_test.cpp
@@ -83,7 +83,15 @@ if(BUILD_TESTING)
   target_link_libraries(sygnal_mcm_interface_tests
     PRIVATE ${PROJECT_NAME} Catch2::Catch2WithMain
   )
-  catch_discover_tests(sygnal_mcm_interface_tests)
+  ament_add_test(
+    sygnal_mcm_interface_tests
+    GENERATE_RESULT_FOR_RETURN_CODE_ZERO
+    COMMAND "$<TARGET_FILE:sygnal_mcm_interface_tests>"
+      -r junit -s
+      -o test_results/${PROJECT_NAME}/sygnal_mcm_interface_tests_output.xml
+    ENV CATCH_CONFIG_CONSOLE_WIDTH=120
+    WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+  )
 
   add_executable(sygnal_command_interface_tests
     test/sygnal_command_interface_test.cpp
@@ -91,7 +99,15 @@ if(BUILD_TESTING)
   target_link_libraries(sygnal_command_interface_tests
     PRIVATE ${PROJECT_NAME} Catch2::Catch2WithMain
   )
-  catch_discover_tests(sygnal_command_interface_tests)
+  ament_add_test(
+    sygnal_command_interface_tests
+    GENERATE_RESULT_FOR_RETURN_CODE_ZERO
+    COMMAND "$<TARGET_FILE:sygnal_command_interface_tests>"
+      -r junit -s
+      -o test_results/${PROJECT_NAME}/sygnal_command_interface_tests_output.xml
+    ENV CATCH_CONFIG_CONSOLE_WIDTH=120
+    WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+  )
 
   if(DEFINED ENV{CAN_AVAILABLE})
     add_executable(sygnal_interface_socketcan_tests
@@ -100,7 +116,15 @@ if(BUILD_TESTING)
     target_link_libraries(sygnal_interface_socketcan_tests
       PRIVATE ${PROJECT_NAME} Catch2::Catch2WithMain
     )
-    catch_discover_tests(sygnal_interface_socketcan_tests)
+    ament_add_test(
+      sygnal_interface_socketcan_tests
+      GENERATE_RESULT_FOR_RETURN_CODE_ZERO
+      COMMAND "$<TARGET_FILE:sygnal_interface_socketcan_tests>"
+        -r junit -s
+        -o test_results/${PROJECT_NAME}/sygnal_interface_socketcan_tests_output.xml
+      ENV CATCH_CONFIG_CONSOLE_WIDTH=120
+      WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+    )
     message(STATUS "CAN_AVAILABLE set - including hardware tests")
   endif()
 endif()

--- a/sygnal_can_interface/sygnal_can_interface_lib/package.xml
+++ b/sygnal_can_interface/sygnal_can_interface_lib/package.xml
@@ -9,8 +9,11 @@
   <author email="zeerekahmad@hotmail.com">Zeerek Ahmad</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <depend>socketcan_adapter</depend>
   <depend>sygnal_dbc</depend>
+
+  <test_depend>catch2</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/sygnal_can_interface/sygnal_can_interface_lib/src/sygnal_interface_socketcan.cpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/src/sygnal_interface_socketcan.cpp
@@ -131,8 +131,6 @@ SendCommandResult SygnalInterfaceSocketcan::sendControlStateCommand(
     return {false, std::nullopt};
   }
 
-  auto data = frame_opt->get_data();
-
   std::optional<std::future<SygnalControlCommandResponse>> future_opt;
   if (expect_reply) {
     std::promise<SygnalControlCommandResponse> promise;

--- a/sygnal_can_interface/sygnal_can_interface_lib/test/sygnal_command_interface_test.cpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/test/sygnal_command_interface_test.cpp
@@ -19,8 +19,6 @@
 
 #if __has_include(<catch2/catch_all.hpp>)
   #include <catch2/catch_all.hpp>
-  #include <catch2/catch_approx.hpp>
-using Catch::Approx;
 #elif __has_include(<catch2/catch.hpp>)
   #include <catch2/catch.hpp>
 #else

--- a/sygnal_can_interface/sygnal_can_interface_lib/test/sygnal_command_interface_test.cpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/test/sygnal_command_interface_test.cpp
@@ -17,7 +17,15 @@
 #include <string>
 #include <vector>
 
-#include <catch2/catch.hpp>
+#if __has_include(<catch2/catch_all.hpp>)
+  #include <catch2/catch_all.hpp>
+  #include <catch2/catch_approx.hpp>
+using Catch::Approx;
+#elif __has_include(<catch2/catch.hpp>)
+  #include <catch2/catch.hpp>
+#else
+  #error "Catch2 headers not found. Please install Catch2 (v2 or v3)."
+#endif
 
 #include "socketcan_adapter/can_frame.hpp"
 

--- a/sygnal_can_interface/sygnal_can_interface_lib/test/sygnal_interface_socketcan_test.cpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/test/sygnal_interface_socketcan_test.cpp
@@ -19,8 +19,12 @@
 
 #if __has_include(<catch2/catch_all.hpp>)
   #include <catch2/catch_all.hpp>
-#else
+  #include <catch2/catch_approx.hpp>
+using Catch::Approx;
+#elif __has_include(<catch2/catch.hpp>)
   #include <catch2/catch.hpp>
+#else
+  #error "Catch2 headers not found. Please install Catch2 (v2 or v3)."
 #endif
 
 #include <algorithm>

--- a/sygnal_can_interface/sygnal_can_interface_lib/test/sygnal_mcm_interface_test.cpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/test/sygnal_mcm_interface_test.cpp
@@ -19,8 +19,6 @@
 
 #if __has_include(<catch2/catch_all.hpp>)
   #include <catch2/catch_all.hpp>
-  #include <catch2/catch_approx.hpp>
-using Catch::Approx;
 #elif __has_include(<catch2/catch.hpp>)
   #include <catch2/catch.hpp>
 #else

--- a/sygnal_can_interface/sygnal_can_interface_lib/test/sygnal_mcm_interface_test.cpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/test/sygnal_mcm_interface_test.cpp
@@ -17,7 +17,15 @@
 #include <string>
 #include <vector>
 
-#include <catch2/catch.hpp>
+#if __has_include(<catch2/catch_all.hpp>)
+  #include <catch2/catch_all.hpp>
+  #include <catch2/catch_approx.hpp>
+using Catch::Approx;
+#elif __has_include(<catch2/catch.hpp>)
+  #include <catch2/catch.hpp>
+#else
+  #error "Catch2 headers not found. Please install Catch2 (v2 or v3)."
+#endif
 
 #include "socketcan_adapter/can_frame.hpp"
 

--- a/sygnal_can_interface/sygnal_can_interface_ros2/src/sygnal_can_interface_node.cpp
+++ b/sygnal_can_interface/sygnal_can_interface_ros2/src/sygnal_can_interface_node.cpp
@@ -22,7 +22,13 @@
 #include <string>
 #include <utility>
 
-#include <magic_enum.hpp>
+#if __has_include(<magic_enum/magic_enum.hpp>)
+  #include <magic_enum/magic_enum.hpp>
+#elif __has_include(<magic_enum.hpp>)
+  #include <magic_enum.hpp>
+#else
+  #error "magic_enum headers not found. Please install magic_enum."
+#endif
 
 #include "sygnal_can_interface_lib/sygnal_command_interface.hpp"
 #include "sygnal_can_interface_lib/sygnal_mcm_interface.hpp"

--- a/sygnal_can_interface/sygnal_can_msgs/CMakeLists.txt
+++ b/sygnal_can_interface/sygnal_can_msgs/CMakeLists.txt
@@ -15,10 +15,8 @@
 cmake_minimum_required(VERSION 3.8)
 project(sygnal_can_msgs)
 
-find_package(ament_cmake REQUIRED)
-find_package(rosidl_default_generators REQUIRED)
-find_package(builtin_interfaces REQUIRED)
-find_package(std_msgs REQUIRED)
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
 set(msg_files
   "msg/McmHeartbeat.msg"

--- a/sygnal_can_interface/sygnal_can_msgs/package.xml
+++ b/sygnal_can_interface/sygnal_can_msgs/package.xml
@@ -8,8 +8,11 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <depend>rosidl_default_generators</depend>
+  <depend>builtin_interfaces</depend>
+  <depend>std_msgs</depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
 

--- a/sygnal_dbc/CMakeLists.txt
+++ b/sygnal_dbc/CMakeLists.txt
@@ -95,9 +95,8 @@ ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_package(CONFIG_EXTRAS "cmake/${PROJECT_NAME}-extras.cmake")
 
 if(BUILD_TESTING)
-  find_package(ament_cmake_pytest REQUIRED)
-  find_package(Catch2 REQUIRED)
-  include(Catch)
+  find_package(ament_cmake_auto REQUIRED)
+  ament_auto_find_test_dependencies()
 
   ament_add_pytest_test(test_mcm_heartbeat_python
     test/test_mcm_heartbeat.py
@@ -106,6 +105,14 @@ if(BUILD_TESTING)
 
   add_executable(test_mcm_heartbeat_cpp test/test_mcm_heartbeat.cpp)
   target_link_libraries(test_mcm_heartbeat_cpp PRIVATE Catch2::Catch2WithMain ${PROJECT_NAME})
-  catch_discover_tests(test_mcm_heartbeat_cpp)
+  ament_add_test(
+    test_mcm_heartbeat_cpp
+    GENERATE_RESULT_FOR_RETURN_CODE_ZERO
+    COMMAND "$<TARGET_FILE:test_mcm_heartbeat_cpp>"
+      -r junit -s
+      -o test_results/${PROJECT_NAME}/test_mcm_heartbeat_cpp_output.xml
+    ENV CATCH_CONFIG_CONSOLE_WIDTH=120
+    WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+  )
 
 endif()

--- a/sygnal_dbc/CMakeLists.txt
+++ b/sygnal_dbc/CMakeLists.txt
@@ -15,7 +15,8 @@ cmake_minimum_required(VERSION 3.5)
 
 project(sygnal_dbc VERSION 0.1.0 LANGUAGES C CXX)
 
-find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 find_package(Python3 COMPONENTS Interpreter REQUIRED)
 include(GNUInstallDirs)
 
@@ -95,7 +96,6 @@ ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_package(CONFIG_EXTRAS "cmake/${PROJECT_NAME}-extras.cmake")
 
 if(BUILD_TESTING)
-  find_package(ament_cmake_auto REQUIRED)
   ament_auto_find_test_dependencies()
   find_package(Catch2 REQUIRED)
 

--- a/sygnal_dbc/CMakeLists.txt
+++ b/sygnal_dbc/CMakeLists.txt
@@ -97,6 +97,7 @@ ament_package(CONFIG_EXTRAS "cmake/${PROJECT_NAME}-extras.cmake")
 if(BUILD_TESTING)
   find_package(ament_cmake_auto REQUIRED)
   ament_auto_find_test_dependencies()
+  find_package(Catch2 REQUIRED)
 
   ament_add_pytest_test(test_mcm_heartbeat_python
     test/test_mcm_heartbeat.py

--- a/sygnal_dbc/package.xml
+++ b/sygnal_dbc/package.xml
@@ -8,6 +8,7 @@
   <author email="zeerekahmad@hotmail.com">Zeerek Ahmad</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>python3-cantools-pip</buildtool_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>

--- a/sygnal_dbc/test/test_mcm_heartbeat.cpp
+++ b/sygnal_dbc/test/test_mcm_heartbeat.cpp
@@ -16,8 +16,6 @@
 
 #if __has_include(<catch2/catch_all.hpp>)
   #include <catch2/catch_all.hpp>
-  #include <catch2/catch_approx.hpp>
-using Catch::Approx;
 #elif __has_include(<catch2/catch.hpp>)
   #include <catch2/catch.hpp>
 #else

--- a/sygnal_dbc/test/test_mcm_heartbeat.cpp
+++ b/sygnal_dbc/test/test_mcm_heartbeat.cpp
@@ -16,6 +16,8 @@
 
 #if __has_include(<catch2/catch_all.hpp>)
   #include <catch2/catch_all.hpp>
+  #include <catch2/catch_approx.hpp>
+using Catch::Approx;
 #elif __has_include(<catch2/catch.hpp>)
   #include <catch2/catch.hpp>
 #else

--- a/sygnal_fault_clear/CMakeLists.txt
+++ b/sygnal_fault_clear/CMakeLists.txt
@@ -20,27 +20,8 @@ endif()
 
 set(CMAKE_CXX_STANDARD 17)
 
-# find dependencies
-find_package(ament_cmake REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(rclcpp_action REQUIRED)
-find_package(rclcpp_lifecycle REQUIRED)
-find_package(rclcpp_components REQUIRED)
-find_package(std_msgs REQUIRED)
-find_package(std_srvs REQUIRED)
-
-include_directories(
-  include
-)
-
-set(dependencies
-  rclcpp
-  rclcpp_action
-  rclcpp_lifecycle
-  rclcpp_components
-  std_msgs
-  std_srvs
-)
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
 set(library_name ${PROJECT_NAME}_lib)
 add_library(
@@ -48,8 +29,18 @@ add_library(
   src/fault_clear_node.cpp
 )
 
-ament_target_dependencies(${library_name}
-  ${dependencies}
+target_include_directories(${library_name} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include>"
+)
+
+target_link_libraries(${library_name} PUBLIC
+  ${std_msgs_TARGETS}
+  ${std_srvs_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_action::rclcpp_action
+  rclcpp_lifecycle::rclcpp_lifecycle
+  rclcpp_components::component
 )
 
 set(executable_name sygnal_fault_clear)

--- a/sygnal_fault_clear/package.xml
+++ b/sygnal_fault_clear/package.xml
@@ -8,6 +8,7 @@
   <license>Apache 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_action</depend>
   <depend>rclcpp_lifecycle</depend>


### PR DESCRIPTION
1. Adds jazzy, kilted, and rolling to the ROS2 build and test CI
2. addresses all catch2 v2/v3 differences across ROS distrobutions
3. addresses all magic_enum include differences across ROS distrobutions
4. modernizes cmake away from ament_target_dependencies in favor of target_link_libraries. use ament_cmake_auto where possible
5. Removes old TODOs and unused variables