### PR TITLE
Fix: store control_command subscription in on_activate

### DIFF
--- a/sygnal_can_interface/sygnal_can_interface_ros2/src/sygnal_can_interface_node.cpp
+++ b/sygnal_can_interface/sygnal_can_interface_ros2/src/sygnal_can_interface_node.cpp
@@ -134,7 +134,7 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Sygnal
     entry.publisher->on_activate();
   }
 
-  create_subscription<sygnal_can_msgs::msg::ControlCommand>(
+  control_command_sub_ = create_subscription<sygnal_can_msgs::msg::ControlCommand>(
     "~/control_command",
     rclcpp::QoS(10),
     std::bind(&SygnalCanInterfaceNode::controlCommandCallback, this, std::placeholders::_1));


### PR DESCRIPTION
## Summary
- The `~/control_command` topic subscription created in `on_activate()` was not assigned to the `control_command_sub_` member variable
- The subscription was immediately destroyed when the temporary `SharedPtr` went out of scope, resulting in zero subscribers on the topic
- Any node publishing to `~/control_command` (e.g., a command bridge) would see `Subscription count: 0` and no CAN frames would be generated from the topic

## Root Cause
Line 137 of `sygnal_can_interface_node.cpp` called `create_subscription<>()` without storing the return value. The member `control_command_sub_` (declared in the header at line 127) was never assigned.

## Fix
One-line change: `control_command_sub_ = create_subscription<>(...)`

## How It Was Found
During integration testing of a control pipeline that publishes multi-axis commands to the `~/control_command` topic. `ros2 topic info` showed `Subscription count: 0` despite the node being in ACTIVE lifecycle state. `ros2 node info` confirmed the subscription was not listed. The `send_control_command` service worked correctly (separate code path), masking the bug in topic-based usage.

## Test plan
- [x] `ros2 topic info ~/control_command` shows `Subscription count: 1` after activation
- [x] Publishing to `~/control_command` generates CAN frames on the configured interface
- [x] `ros2 node info` lists `~/control_command` under Subscribers when node is ACTIVE