### PR TITLE
Add MCM & MVEC Endpoint Structs to Reduce Client Const Definitions

### DIFF
--- a/mvec/mvec_lib/include/mvec_lib/mvec_relay_socketcan.hpp
+++ b/mvec/mvec_lib/include/mvec_lib/mvec_relay_socketcan.hpp
@@ -26,6 +26,13 @@
 namespace polymath::sygnal
 {
 
+/// @brief Represents an MVEC Relay endpoint..
+struct MvecEndpoint
+{
+  uint8_t id;
+  std::string_view name;
+};
+
 /// @brief MVEC relay controller with async SocketCAN communication
 /// Provides high-level interface for MVEC relay control with thread-safe promise/future pattern
 class MvecRelaySocketcan
@@ -44,6 +51,11 @@ public:
   /// @param relay_id Relay ID (0-11)
   /// @param relay_state Relay state (0=off, 1=on)
   void set_relay_in_command(uint8_t relay_id, uint8_t relay_state);
+
+  /// @brief Set relay command state
+  /// @param relay_id Relay ID (0-11)
+  /// @param relay_state Relay state (0=off, 1=on)
+  void set_relay_in_command(MvecEndpoint relay, uint8_t relay_state);
 
   /// @brief Clear all relay commands
   void clear_relay();

--- a/mvec/mvec_lib/include/mvec_lib/mvec_relay_socketcan.hpp
+++ b/mvec/mvec_lib/include/mvec_lib/mvec_relay_socketcan.hpp
@@ -26,7 +26,7 @@
 namespace polymath::sygnal
 {
 
-/// @brief Represents an MVEC Relay endpoint..
+/// @brief Represents a single relay on the MVEC.
 struct MvecEndpoint
 {
   uint8_t id;

--- a/mvec/mvec_lib/include/mvec_lib/mvec_relay_socketcan.hpp
+++ b/mvec/mvec_lib/include/mvec_lib/mvec_relay_socketcan.hpp
@@ -53,7 +53,7 @@ public:
   void set_relay_in_command(uint8_t relay_id, uint8_t relay_state);
 
   /// @brief Set relay command state
-  /// @param relay_id Relay ID (0-11)
+  /// @param relay Relay Endpoint with relay_id (0-11)
   /// @param relay_state Relay state (0=off, 1=on)
   void set_relay_in_command(MvecEndpoint relay, uint8_t relay_state);
 

--- a/mvec/mvec_lib/src/mvec_relay_socketcan.cpp
+++ b/mvec/mvec_lib/src/mvec_relay_socketcan.cpp
@@ -79,8 +79,7 @@ void MvecRelaySocketcan::set_relay_in_command(uint8_t relay_id, uint8_t relay_st
 
 void MvecRelaySocketcan::set_relay_in_command(MvecEndpoint relay, uint8_t relay_state)
 {
-  /// TODO: (zeerek) Where do we check against the population table? When do we initially query the population table?
-  relay_impl_.set_relay_in_command(relay.id, relay_state);
+  set_relay_in_command(relay.id, relay_state);
 }
 
 void MvecRelaySocketcan::clear_relay()

--- a/mvec/mvec_lib/src/mvec_relay_socketcan.cpp
+++ b/mvec/mvec_lib/src/mvec_relay_socketcan.cpp
@@ -77,6 +77,12 @@ void MvecRelaySocketcan::set_relay_in_command(uint8_t relay_id, uint8_t relay_st
   relay_impl_.set_relay_in_command(relay_id, relay_state);
 }
 
+void MvecRelaySocketcan::set_relay_in_command(MvecEndpoint relay, uint8_t relay_state)
+{
+  /// TODO: (zeerek) Where do we check against the population table? When do we initially query the population table?
+  relay_impl_.set_relay_in_command(relay.id, relay_state);
+}
+
 void MvecRelaySocketcan::clear_relay()
 {
   relay_impl_.clearRelayCommands();

--- a/sygnal_can_interface/sygnal_can_interface_lib/include/sygnal_can_interface_lib/sygnal_interface_socketcan.hpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/include/sygnal_can_interface_lib/sygnal_interface_socketcan.hpp
@@ -43,6 +43,27 @@ struct McmSystem
   SygnalMcmInterface mcm_1;
 };
 
+/// @brief Represents an interface endpoint in the Sygnal CAN interface
+struct InterfaceEndpoint
+{
+  uint8_t bus_id;
+  uint8_t subsystem_id;
+  uint8_t interface_id;
+  int min_value;
+  int max_value;
+  bool is_continuous;
+  std::string_view name;
+};
+
+/// @brief Represents a relay endpoint in the Sygnal CAN interface
+struct RelayEndpoint
+{
+  uint8_t bus_id;
+  uint8_t subsystem_id;
+  uint8_t relay_id;
+  std::string_view name;
+};
+
 constexpr uint32_t MAX_PROMISE_QUEUE_LENGTH = 100;
 
 /// @brief Combined Sygnal MCM and Control interface with SocketCAN communication
@@ -80,6 +101,18 @@ public:
     bool expect_reply,
     std::string & error_message);
 
+  /// @brief Send control state (enable/disable) command
+  /// @param interface Interface endpoint to control
+  /// @param control_state MCM_CONTROL or HUMAN_CONTROL
+  /// @param expect_reply If true, returns future for response; if false, fire-and-forget
+  /// @param error_message Populated on failure
+  /// @return Result with success flag and optional response future
+  SendCommandResult sendControlStateCommand(
+    InterfaceEndpoint interface,
+    SygnalControlState control_state,
+    bool expect_reply,
+    std::string & error_message);
+
   /// @brief Send control command with value
   /// @param bus_id Bus address
   /// @param interface_id Interface to control
@@ -95,6 +128,18 @@ public:
     bool expect_reply,
     std::string & error_message);
 
+  /// @brief Send control command with value
+  /// @param interface Interface endpoint to control
+  /// @param value Control value
+  /// @param expect_reply If true, returns future for response; if false, fire-and-forget
+  /// @param error_message Populated on failure
+  /// @return Result with success flag and optional response future
+  SendCommandResult sendControlCommand(
+    InterfaceEndpoint interface,
+    double value,
+    bool expect_reply,
+    std::string & error_message);
+
   /// @brief Send relay command
   /// @param bus_id Bus address
   /// @param subsystem_id Subsystem/relay to control
@@ -104,6 +149,15 @@ public:
   /// @return Result with success flag and optional response future
   SendCommandResult sendRelayCommand(
     uint8_t bus_id, uint8_t subsystem_id, bool relay_state, bool expect_reply, std::string & error_message);
+
+  /// @brief Send relay command
+  /// @param interface Interface endpoint to control
+  /// @param relay_state Enable or disable
+  /// @param expect_reply If true, returns future for response; if false, fire-and-forget
+  /// @param error_message Populated on failure
+  /// @return Result with success flag and optional response future
+  SendCommandResult sendRelayCommand(
+    InterfaceEndpoint interface, bool relay_state, bool expect_reply, std::string & error_message);
 
 private:
   std::shared_ptr<socketcan::SocketcanAdapter> socketcan_adapter_;

--- a/sygnal_can_interface/sygnal_can_interface_lib/include/sygnal_can_interface_lib/sygnal_interface_socketcan.hpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/include/sygnal_can_interface_lib/sygnal_interface_socketcan.hpp
@@ -43,7 +43,8 @@ struct McmSystem
   SygnalMcmInterface mcm_1;
 };
 
-/// @brief Represents an interface endpoint in the Sygnal CAN interface
+/// @brief Represents a single control interface in Sygnal's System.
+///        Interfaces can either take floats(default) or ints as inputs.
 struct InterfaceEndpoint
 {
   uint8_t bus_id;
@@ -51,7 +52,7 @@ struct InterfaceEndpoint
   uint8_t interface_id;
   int min_value;
   int max_value;
-  bool is_continuous;
+  bool is_int;
   std::string_view name;
 };
 

--- a/sygnal_can_interface/sygnal_can_interface_lib/include/sygnal_can_interface_lib/sygnal_interface_socketcan.hpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/include/sygnal_can_interface_lib/sygnal_interface_socketcan.hpp
@@ -108,10 +108,7 @@ public:
   /// @param error_message Populated on failure
   /// @return Result with success flag and optional response future
   SendCommandResult sendControlStateCommand(
-    InterfaceEndpoint interface,
-    SygnalControlState control_state,
-    bool expect_reply,
-    std::string & error_message);
+    InterfaceEndpoint interface, SygnalControlState control_state, bool expect_reply, std::string & error_message);
 
   /// @brief Send control command with value
   /// @param bus_id Bus address
@@ -135,10 +132,7 @@ public:
   /// @param error_message Populated on failure
   /// @return Result with success flag and optional response future
   SendCommandResult sendControlCommand(
-    InterfaceEndpoint interface,
-    double value,
-    bool expect_reply,
-    std::string & error_message);
+    InterfaceEndpoint interface, double value, bool expect_reply, std::string & error_message);
 
   /// @brief Send relay command
   /// @param bus_id Bus address

--- a/sygnal_can_interface/sygnal_can_interface_lib/include/sygnal_can_interface_lib/sygnal_interface_socketcan.hpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/include/sygnal_can_interface_lib/sygnal_interface_socketcan.hpp
@@ -56,7 +56,7 @@ struct InterfaceEndpoint
   std::string_view name;
 };
 
-/// @brief Represents a relay endpoint in the Sygnal CAN interface
+/// @brief Represents a single relay in Sygnal's System.
 struct RelayEndpoint
 {
   uint8_t bus_id;

--- a/sygnal_can_interface/sygnal_can_interface_lib/src/sygnal_interface_socketcan.cpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/src/sygnal_interface_socketcan.cpp
@@ -153,12 +153,10 @@ SendCommandResult SygnalInterfaceSocketcan::sendControlStateCommand(
 }
 
 SendCommandResult SygnalInterfaceSocketcan::sendControlStateCommand(
-  InterfaceEndpoint interface,
-  SygnalControlState control_state,
-  bool expect_reply,
-  std::string & error_message)
+  InterfaceEndpoint interface, SygnalControlState control_state, bool expect_reply, std::string & error_message)
 {
-  return sendControlStateCommand(interface.bus_id, interface.interface_id, interface.subsystem_id, control_state, expect_reply, error_message);
+  return sendControlStateCommand(
+    interface.bus_id, interface.interface_id, interface.subsystem_id, control_state, expect_reply, error_message);
 }
 
 SendCommandResult SygnalInterfaceSocketcan::sendControlCommand(
@@ -198,14 +196,11 @@ SendCommandResult SygnalInterfaceSocketcan::sendControlCommand(
 }
 
 SendCommandResult SygnalInterfaceSocketcan::sendControlCommand(
-  InterfaceEndpoint interface,
-  double value,
-  bool expect_reply,
-  std::string & error_message)
+  InterfaceEndpoint interface, double value, bool expect_reply, std::string & error_message)
 {
-  return sendControlCommand(interface.bus_id, interface.interface_id, interface.subsystem_id, value, expect_reply, error_message);
+  return sendControlCommand(
+    interface.bus_id, interface.interface_id, interface.subsystem_id, value, expect_reply, error_message);
 }
-
 
 SendCommandResult SygnalInterfaceSocketcan::sendRelayCommand(
   uint8_t bus_id, uint8_t subsystem_id, bool relay_state, bool expect_reply, std::string & error_message)

--- a/sygnal_can_interface/sygnal_can_interface_lib/src/sygnal_interface_socketcan.cpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/src/sygnal_interface_socketcan.cpp
@@ -152,6 +152,15 @@ SendCommandResult SygnalInterfaceSocketcan::sendControlStateCommand(
   return {true, std::move(future_opt)};
 }
 
+SendCommandResult SygnalInterfaceSocketcan::sendControlStateCommand(
+  InterfaceEndpoint interface,
+  SygnalControlState control_state,
+  bool expect_reply,
+  std::string & error_message)
+{
+  return sendControlStateCommand(interface.bus_id, interface.interface_id, interface.subsystem_id, control_state, expect_reply, error_message);
+}
+
 SendCommandResult SygnalInterfaceSocketcan::sendControlCommand(
   uint8_t bus_id,
   uint8_t interface_id,
@@ -188,6 +197,16 @@ SendCommandResult SygnalInterfaceSocketcan::sendControlCommand(
   return {true, std::move(future_opt)};
 }
 
+SendCommandResult SygnalInterfaceSocketcan::sendControlCommand(
+  InterfaceEndpoint interface,
+  double value,
+  bool expect_reply,
+  std::string & error_message)
+{
+  return sendControlCommand(interface.bus_id, interface.interface_id, interface.subsystem_id, value, expect_reply, error_message);
+}
+
+
 SendCommandResult SygnalInterfaceSocketcan::sendRelayCommand(
   uint8_t bus_id, uint8_t subsystem_id, bool relay_state, bool expect_reply, std::string & error_message)
 {
@@ -216,6 +235,12 @@ SendCommandResult SygnalInterfaceSocketcan::sendRelayCommand(
   }
 
   return {true, std::move(future_opt)};
+}
+
+SendCommandResult SygnalInterfaceSocketcan::sendRelayCommand(
+  InterfaceEndpoint interface, bool relay_state, bool expect_reply, std::string & error_message)
+{
+  return sendRelayCommand(interface.bus_id, interface.subsystem_id, relay_state, expect_reply, error_message);
 }
 
 }  // namespace polymath::sygnal

--- a/sygnal_can_interface/sygnal_can_interface_lib/src/sygnal_interface_socketcan.cpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/src/sygnal_interface_socketcan.cpp
@@ -167,6 +167,7 @@ SendCommandResult SygnalInterfaceSocketcan::sendControlCommand(
   bool expect_reply,
   std::string & error_message)
 {
+  // TODO(ryan): update function def to include min max values and check the value before sending.
   auto frame_opt =
     control_interface_.createControlCommandFrame(bus_id, interface_id, subsystem_id, value, error_message);
 


### PR DESCRIPTION
# Add MCM & MVEC Endpoint Structs to Reduce Client Const Definitions
Add endpoint structs for MCM Interfaces, MCM Relays, and MVEC Relays to help simplify the number of constants the client needs to store.


# Questions:
1. Did I put the structs in the right files? Should they live in those header files or somewhere else?

##  SygnalInterfaceSocketcan
### Structs Added
```
/// @brief Represents an interface endpoint in the Sygnal CAN interface
struct InterfaceEndpoint
{
  uint8_t bus_id;
  uint8_t subsystem_id;
  uint8_t interface_id;
  int min_value;
  int max_value;
  bool is_continuous;
  std::string_view name;
};

/// @brief Represents a relay endpoint in the Sygnal CAN interface
struct RelayEndpoint
{
  uint8_t bus_id;
  uint8_t subsystem_id;
  uint8_t relay_id;
  std::string_view name;
};
```
### Wrapper Functions Added
```
SendCommandResult SygnalInterfaceSocketcan::sendControlStateCommand(
  InterfaceEndpoint interface,
  SygnalControlState control_state,
  bool expect_reply,
  std::string & error_message)
{
  return sendControlStateCommand(interface.bus_id, interface.interface_id, interface.subsystem_id, control_state, expect_reply, error_message);
}

SendCommandResult SygnalInterfaceSocketcan::sendControlCommand(
  InterfaceEndpoint interface,
  double value,
  bool expect_reply,
  std::string & error_message)
{
  return sendControlCommand(interface.bus_id, interface.interface_id, interface.subsystem_id, value, expect_reply, error_message);
}

SendCommandResult SygnalInterfaceSocketcan::sendRelayCommand(
  InterfaceEndpoint interface, bool relay_state, bool expect_reply, std::string & error_message)
{
  return sendRelayCommand(interface.bus_id, interface.subsystem_id, relay_state, expect_reply, error_message);
}
```

##  MvecRelaySocketcan
### Structs Added
```
/// @brief Represents an MVEC Relay endpoint..
struct MvecEndpoint
{
  uint8_t id;
  std::string_view name;
};
```
### Wrapper Functions Added
```
void MvecRelaySocketcan::set_relay_in_command(MvecEndpoint relay, uint8_t relay_state)
{
  relay_impl_.set_relay_in_command(relay.id, relay_state);
}
```
