### PR TITLE
HPO handling first-pass implementation

### DIFF
--- a/sygnal_can_interface/sygnal_can_interface_lib/CMakeLists.txt
+++ b/sygnal_can_interface/sygnal_can_interface_lib/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(
   src/crc8.cpp
   src/sygnal_mcm_interface.cpp
   src/sygnal_command_interface.cpp
+  src/sygnal_hpo_interface.cpp
   src/sygnal_interface_socketcan.cpp
 )
 
@@ -104,6 +105,22 @@ if(BUILD_TESTING)
     COMMAND "$<TARGET_FILE:sygnal_command_interface_tests>"
       -r junit -s
       -o test_results/${PROJECT_NAME}/sygnal_command_interface_tests_output.xml
+    ENV CATCH_CONFIG_CONSOLE_WIDTH=120
+    WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+  )
+
+  add_executable(sygnal_hpo_interface_tests
+    test/sygnal_hpo_interface_test.cpp
+  )
+  target_link_libraries(sygnal_hpo_interface_tests
+    PRIVATE ${PROJECT_NAME} sygnal_dbc::sygnal_dbc Catch2::Catch2WithMain
+  )
+  ament_add_test(
+    sygnal_hpo_interface_tests
+    GENERATE_RESULT_FOR_RETURN_CODE_ZERO
+    COMMAND "$<TARGET_FILE:sygnal_hpo_interface_tests>"
+      -r junit -s
+      -o test_results/${PROJECT_NAME}/sygnal_hpo_interface_tests_output.xml
     ENV CATCH_CONFIG_CONSOLE_WIDTH=120
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
   )

--- a/sygnal_can_interface/sygnal_can_interface_lib/include/sygnal_can_interface_lib/sygnal_hpo_interface.hpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/include/sygnal_can_interface_lib/sygnal_hpo_interface.hpp
@@ -1,0 +1,133 @@
+// Copyright (c) 2025-present Polymath Robotics, Inc. All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SYGNAL_CAN_INTERFACE_LIB__SYGNAL_HPO_INTERFACE_HPP_
+#define SYGNAL_CAN_INTERFACE_LIB__SYGNAL_HPO_INTERFACE_HPP_
+
+#include <array>
+#include <chrono>
+#include <optional>
+#include <string>
+
+#include "socketcan_adapter/can_frame.hpp"
+
+namespace polymath::sygnal
+{
+
+constexpr uint8_t HPO_NUM_INTERFACES = 7;
+
+/// @brief Parsed HPO ControlEnableResponse / ControlCommandResponse.
+///        is_enable_response disambiguates which payload is meaningful:
+///        when true, the `enable` field carries the response; when false,
+///        the `value` field carries the float command response.
+struct HpoControlResponse
+{
+  uint8_t message_id;
+  uint8_t bus_address;
+  double value;
+  bool enable;
+  bool is_enable_response;
+};
+
+/// @brief Parsed HPO ErrorStatus frame fields.
+struct HpoErrorStatus
+{
+  uint8_t bus_address;
+  uint8_t subsystem_id;
+  uint8_t error_type;
+  uint16_t error_can_id;
+  uint8_t config_section_id;
+  uint8_t config_interface_id;
+};
+
+/// @brief Self-contained HPO board representation.
+///
+/// Owns the per-device interface bits (7 per-interface + 1 overall) and produces /
+/// consumes the CAN frames the HPO understands. Frames are routed to the right
+/// instance by `bus_address_`: every parse helper rejects frames that do not match
+/// this device's bus address. Command frames are populated with `bus_address_`
+/// automatically so callers cannot mismatch addresses.
+///
+/// Unlike the MCM, the HPO does not hold a Sygnal state machine. The per-interface
+/// and overall-interface heartbeat signals are 1-bit booleans (true = HPO in control,
+/// false = released). The MCM's SystemState byte is not tracked here.
+class SygnalHpoInterface
+{
+public:
+  SygnalHpoInterface();
+  explicit SygnalHpoInterface(uint8_t bus_address);
+  ~SygnalHpoInterface() = default;
+
+  /// @brief Try to parse a CAN frame as an HPO heartbeat addressed to this device.
+  /// @param frame Raw CAN frame.
+  /// @return true if the frame matched and internal state was updated.
+  bool parseHeartbeatFrame(const socketcan::CanFrame & frame);
+
+  /// @brief Try to parse a CAN frame as a ControlEnableResponse or ControlCommandResponse
+  ///        addressed to this device.
+  /// @param frame Raw CAN frame.
+  /// @return Populated HpoControlResponse on success, std::nullopt otherwise.
+  std::optional<HpoControlResponse> parseControlResponse(const socketcan::CanFrame & frame);
+
+  /// @brief Try to parse a CAN frame as an ErrorStatus addressed to this device.
+  /// @param frame Raw CAN frame.
+  /// @return Populated HpoErrorStatus on success, std::nullopt otherwise.
+  std::optional<HpoErrorStatus> parseErrorFrame(const socketcan::CanFrame & frame);
+
+  /// @brief Build a ControlEnable frame for this device.
+  /// @param message_id 8-bit HPO MessageID.
+  /// @param enable true to grant HPO control, false to release.
+  /// @param[out] error_message Populated on failure.
+  /// @return Packed CAN frame on success.
+  std::optional<socketcan::CanFrame> createControlEnableFrame(
+    uint8_t message_id, bool enable, std::string & error_message);
+
+  /// @brief Build a ControlCommand frame for this device.
+  /// @param message_id 8-bit HPO MessageID.
+  /// @param value Command value (encoded as float per the DBC).
+  /// @param[out] error_message Populated on failure.
+  /// @return Packed CAN frame on success.
+  std::optional<socketcan::CanFrame> createControlCommandFrame(
+    uint8_t message_id, double value, std::string & error_message);
+
+  uint8_t get_bus_address() const
+  {
+    return bus_address_;
+  }
+
+  std::array<bool, HPO_NUM_INTERFACES> get_interface_states() const
+  {
+    return hpo_interface_states_;
+  }
+
+  bool get_overall_interface_state() const
+  {
+    return hpo_overall_interface_state_;
+  }
+
+  std::chrono::system_clock::time_point get_last_heartbeat_timestamp() const
+  {
+    return last_heartbeat_timestamp_;
+  }
+
+private:
+  uint8_t bus_address_;
+  std::array<bool, HPO_NUM_INTERFACES> hpo_interface_states_;
+  bool hpo_overall_interface_state_;
+  std::chrono::system_clock::time_point last_heartbeat_timestamp_;
+};
+
+}  // namespace polymath::sygnal
+
+#endif  // SYGNAL_CAN_INTERFACE_LIB__SYGNAL_HPO_INTERFACE_HPP_

--- a/sygnal_can_interface/sygnal_can_interface_lib/src/sygnal_hpo_interface.cpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/src/sygnal_hpo_interface.cpp
@@ -1,0 +1,254 @@
+// Copyright (c) 2025-present Polymath Robotics, Inc. All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "sygnal_can_interface_lib/sygnal_hpo_interface.hpp"
+
+#include <array>
+#include <chrono>
+#include <string>
+
+#include "sygnal_can_interface_lib/crc8.hpp"
+#include "sygnal_dbc/hpo_control.h"
+#include "sygnal_dbc/hpo_error.h"
+#include "sygnal_dbc/hpo_heartbeat.h"
+
+namespace polymath::sygnal
+{
+
+SygnalHpoInterface::SygnalHpoInterface()
+: bus_address_(0)
+, hpo_overall_interface_state_(false)
+{
+  hpo_interface_states_.fill(false);
+}
+
+SygnalHpoInterface::SygnalHpoInterface(uint8_t bus_address)
+: bus_address_(bus_address)
+, hpo_overall_interface_state_(false)
+{
+  hpo_interface_states_.fill(false);
+}
+
+bool SygnalHpoInterface::parseHeartbeatFrame(const socketcan::CanFrame & frame)
+{
+  if (HPO_HEARTBEAT_HEARTBEAT_FRAME_ID != frame.get_id()) {
+    return false;
+  }
+
+  auto frame_copy = frame.get_frame();
+
+  if (!check_crc8(reinterpret_cast<uint8_t *>(frame_copy.data))) {
+    return false;
+  }
+
+  hpo_heartbeat_heartbeat_t unpacked;
+  if (0 != hpo_heartbeat_heartbeat_init(&unpacked)) {
+    return false;
+  }
+
+  if (0 != hpo_heartbeat_heartbeat_unpack(&unpacked, frame_copy.data, frame_copy.len)) {
+    return false;
+  }
+
+  if (bus_address_ != unpacked.bus_address) {
+    return false;
+  }
+
+  last_heartbeat_timestamp_ = std::chrono::system_clock::now();
+
+  hpo_interface_states_[0] = (0 != unpacked.interface0_state);
+  hpo_interface_states_[1] = (0 != unpacked.interface1_state);
+  hpo_interface_states_[2] = (0 != unpacked.interface2_state);
+  hpo_interface_states_[3] = (0 != unpacked.interface3_state);
+  hpo_interface_states_[4] = (0 != unpacked.interface4_state);
+  hpo_interface_states_[5] = (0 != unpacked.interface5_state);
+  hpo_interface_states_[6] = (0 != unpacked.interface6_state);
+  hpo_overall_interface_state_ = (0 != unpacked.overall_interface_state);
+
+  return true;
+}
+
+std::optional<HpoControlResponse> SygnalHpoInterface::parseControlResponse(const socketcan::CanFrame & frame)
+{
+  auto frame_copy = frame.get_frame();
+  const uint32_t frame_id = frame.get_id();
+
+  if (
+    HPO_CONTROL_CONTROL_ENABLE_RESPONSE_FRAME_ID != frame_id &&
+    HPO_CONTROL_CONTROL_COMMAND_RESPONSE_FRAME_ID != frame_id)
+  {
+    return std::nullopt;
+  }
+
+  if (!check_crc8(reinterpret_cast<uint8_t *>(frame_copy.data))) {
+    return std::nullopt;
+  }
+
+  HpoControlResponse response{};
+
+  if (HPO_CONTROL_CONTROL_ENABLE_RESPONSE_FRAME_ID == frame_id) {
+    hpo_control_control_enable_response_t unpacked;
+    if (0 != hpo_control_control_enable_response_init(&unpacked)) {
+      return std::nullopt;
+    }
+    if (0 != hpo_control_control_enable_response_unpack(&unpacked, frame_copy.data, frame_copy.len)) {
+      return std::nullopt;
+    }
+    if (bus_address_ != unpacked.bus_address) {
+      return std::nullopt;
+    }
+
+    response.is_enable_response = true;
+    response.bus_address = unpacked.bus_address;
+    response.message_id = unpacked.message_id;
+    response.enable = (0 != unpacked.enable);
+    response.value = 0.0;
+    return response;
+  }
+
+  hpo_control_control_command_response_t unpacked;
+  if (0 != hpo_control_control_command_response_init(&unpacked)) {
+    return std::nullopt;
+  }
+  if (0 != hpo_control_control_command_response_unpack(&unpacked, frame_copy.data, frame_copy.len)) {
+    return std::nullopt;
+  }
+  if (bus_address_ != unpacked.bus_address) {
+    return std::nullopt;
+  }
+
+  response.is_enable_response = false;
+  response.bus_address = unpacked.bus_address;
+  response.message_id = unpacked.message_id;
+  response.value = hpo_control_control_command_response_value_decode(unpacked.value);
+  response.enable = false;
+  return response;
+}
+
+std::optional<HpoErrorStatus> SygnalHpoInterface::parseErrorFrame(const socketcan::CanFrame & frame)
+{
+  if (HPO_ERROR_ERROR_STATUS_FRAME_ID != frame.get_id()) {
+    return std::nullopt;
+  }
+
+  auto frame_copy = frame.get_frame();
+
+  if (!check_crc8(reinterpret_cast<uint8_t *>(frame_copy.data))) {
+    return std::nullopt;
+  }
+
+  hpo_error_error_status_t unpacked;
+  if (0 != hpo_error_error_status_init(&unpacked)) {
+    return std::nullopt;
+  }
+  if (0 != hpo_error_error_status_unpack(&unpacked, frame_copy.data, frame_copy.len)) {
+    return std::nullopt;
+  }
+  if (bus_address_ != unpacked.bus_address) {
+    return std::nullopt;
+  }
+
+  HpoErrorStatus status{};
+  status.bus_address = unpacked.bus_address;
+  status.subsystem_id = unpacked.subsystem_id;
+  status.error_type = unpacked.error_type;
+  status.error_can_id = unpacked.error_canid;
+  status.config_section_id = unpacked.config_section_id;
+  status.config_interface_id = unpacked.config_interface_id;
+  return status;
+}
+
+std::optional<socketcan::CanFrame> SygnalHpoInterface::createControlEnableFrame(
+  uint8_t message_id, bool enable, std::string & error_message)
+{
+  polymath::socketcan::CanFrame frame;
+  uint8_t buffer[CAN_MAX_DLC];
+  hpo_control_control_enable_t unpacked;
+
+  if (0 != hpo_control_control_enable_init(&unpacked)) {
+    error_message += "Unable to initialize hpo_control_control_enable_t. \n";
+    return std::nullopt;
+  }
+
+  unpacked.bus_address = bus_address_;
+  unpacked.message_id = message_id;
+  unpacked.enable = enable ? 1 : 0;
+  unpacked.crc = 0;
+
+  if (!hpo_control_control_enable_pack(buffer, &unpacked, sizeof(buffer))) {
+    error_message += "Could not pack hpo_control_control_enable_t. \n";
+    return std::nullopt;
+  }
+
+  unpacked.crc = generate_crc8(buffer);
+  if (!hpo_control_control_enable_pack(buffer, &unpacked, sizeof(buffer))) {
+    error_message += "Could not pack hpo_control_control_enable_t. \n";
+    return std::nullopt;
+  }
+
+  std::array<unsigned char, CAN_MAX_DLC> packed_data;
+  for (size_t i = 0; i < packed_data.size(); ++i) {
+    packed_data[i] = buffer[i];
+  }
+
+  frame.set_can_id(HPO_CONTROL_CONTROL_ENABLE_FRAME_ID);
+  frame.set_len(HPO_CONTROL_CONTROL_ENABLE_LENGTH);
+  frame.set_data(packed_data);
+
+  return frame;
+}
+
+std::optional<socketcan::CanFrame> SygnalHpoInterface::createControlCommandFrame(
+  uint8_t message_id, double value, std::string & error_message)
+{
+  polymath::socketcan::CanFrame frame;
+  uint8_t buffer[CAN_MAX_DLC];
+  hpo_control_control_command_t unpacked;
+
+  if (0 != hpo_control_control_command_init(&unpacked)) {
+    error_message += "Unable to initialize hpo_control_control_command_t. \n";
+    return std::nullopt;
+  }
+
+  unpacked.bus_address = bus_address_;
+  unpacked.message_id = message_id;
+  // Count8 rolling counter is hard-coded to 0 for now (design doc open question #1).
+  unpacked.count8 = hpo_control_control_command_count8_encode(0.0);
+  unpacked.value = hpo_control_control_command_value_encode(value);
+  unpacked.crc = 0;
+
+  if (!hpo_control_control_command_pack(buffer, &unpacked, sizeof(buffer))) {
+    error_message += "Could not pack hpo_control_control_command_t. \n";
+    return std::nullopt;
+  }
+
+  unpacked.crc = generate_crc8(buffer);
+  if (!hpo_control_control_command_pack(buffer, &unpacked, sizeof(buffer))) {
+    error_message += "Could not pack hpo_control_control_command_t. \n";
+    return std::nullopt;
+  }
+
+  std::array<unsigned char, CAN_MAX_DLC> packed_data;
+  for (size_t i = 0; i < packed_data.size(); ++i) {
+    packed_data[i] = buffer[i];
+  }
+
+  frame.set_can_id(HPO_CONTROL_CONTROL_COMMAND_FRAME_ID);
+  frame.set_len(HPO_CONTROL_CONTROL_COMMAND_LENGTH);
+  frame.set_data(packed_data);
+
+  return frame;
+}
+
+}  // namespace polymath::sygnal

--- a/sygnal_can_interface/sygnal_can_interface_lib/test/sygnal_hpo_interface_test.cpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/test/sygnal_hpo_interface_test.cpp
@@ -1,0 +1,371 @@
+// Copyright (c) 2025-present Polymath Robotics, Inc. All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "sygnal_can_interface_lib/sygnal_hpo_interface.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <string>
+
+#if __has_include(<catch2/catch_all.hpp>)
+  #include <catch2/catch_all.hpp>
+#elif __has_include(<catch2/catch.hpp>)
+  #include <catch2/catch.hpp>
+#else
+  #error "Catch2 headers not found. Please install Catch2 (v2 or v3)."
+#endif
+
+#include "socketcan_adapter/can_frame.hpp"
+#include "sygnal_can_interface_lib/crc8.hpp"
+#include "sygnal_dbc/hpo_control.h"
+#include "sygnal_dbc/hpo_error.h"
+#include "sygnal_dbc/hpo_heartbeat.h"
+
+using polymath::sygnal::HPO_NUM_INTERFACES;
+using polymath::sygnal::HpoControlResponse;
+using polymath::sygnal::HpoErrorStatus;
+using polymath::sygnal::SygnalHpoInterface;
+
+namespace
+{
+
+constexpr uint8_t TEST_BUS_ADDRESS = 3;
+constexpr uint8_t OTHER_BUS_ADDRESS = 4;
+
+polymath::socketcan::CanFrame makeFrame(uint32_t can_id, const uint8_t * data, uint8_t len)
+{
+  polymath::socketcan::CanFrame frame;
+  frame.set_can_id(can_id);
+  std::array<unsigned char, CAN_MAX_DLC> bytes;
+  bytes.fill(0);
+  for (size_t i = 0; i < len && i < CAN_MAX_DLC; ++i) {
+    bytes[i] = data[i];
+  }
+  frame.set_data(bytes);
+  frame.set_len(len);
+  return frame;
+}
+
+polymath::socketcan::CanFrame buildHpoHeartbeat(
+  uint8_t bus_address, const std::array<bool, HPO_NUM_INTERFACES> & interface_states, bool overall_state)
+{
+  hpo_heartbeat_heartbeat_t msg;
+  hpo_heartbeat_heartbeat_init(&msg);
+  msg.bus_address = bus_address;
+  msg.subsystem_id = 0;
+  msg.system_state = 0;
+  msg.interface0_state = interface_states[0] ? 1 : 0;
+  msg.interface1_state = interface_states[1] ? 1 : 0;
+  msg.interface2_state = interface_states[2] ? 1 : 0;
+  msg.interface3_state = interface_states[3] ? 1 : 0;
+  msg.interface4_state = interface_states[4] ? 1 : 0;
+  msg.interface5_state = interface_states[5] ? 1 : 0;
+  msg.interface6_state = interface_states[6] ? 1 : 0;
+  msg.overall_interface_state = overall_state ? 1 : 0;
+  msg.count16 = 0;
+  msg.crc = 0;
+
+  uint8_t buffer[CAN_MAX_DLC];
+  hpo_heartbeat_heartbeat_pack(buffer, &msg, sizeof(buffer));
+  msg.crc = polymath::sygnal::generate_crc8(buffer);
+  hpo_heartbeat_heartbeat_pack(buffer, &msg, sizeof(buffer));
+  return makeFrame(HPO_HEARTBEAT_HEARTBEAT_FRAME_ID, buffer, HPO_HEARTBEAT_HEARTBEAT_LENGTH);
+}
+
+polymath::socketcan::CanFrame buildHpoControlEnableResponse(uint8_t bus_address, uint8_t message_id, bool enable)
+{
+  hpo_control_control_enable_response_t msg;
+  hpo_control_control_enable_response_init(&msg);
+  msg.bus_address = bus_address;
+  msg.message_id = message_id;
+  msg.enable = enable ? 1 : 0;
+  msg.crc = 0;
+
+  uint8_t buffer[CAN_MAX_DLC];
+  hpo_control_control_enable_response_pack(buffer, &msg, sizeof(buffer));
+  msg.crc = polymath::sygnal::generate_crc8(buffer);
+  hpo_control_control_enable_response_pack(buffer, &msg, sizeof(buffer));
+  return makeFrame(HPO_CONTROL_CONTROL_ENABLE_RESPONSE_FRAME_ID, buffer, HPO_CONTROL_CONTROL_ENABLE_RESPONSE_LENGTH);
+}
+
+polymath::socketcan::CanFrame buildHpoControlCommandResponse(uint8_t bus_address, uint8_t message_id, double value)
+{
+  hpo_control_control_command_response_t msg;
+  hpo_control_control_command_response_init(&msg);
+  msg.bus_address = bus_address;
+  msg.message_id = message_id;
+  msg.count8 = 0;
+  msg.value = hpo_control_control_command_response_value_encode(value);
+  msg.crc = 0;
+
+  uint8_t buffer[CAN_MAX_DLC];
+  hpo_control_control_command_response_pack(buffer, &msg, sizeof(buffer));
+  msg.crc = polymath::sygnal::generate_crc8(buffer);
+  hpo_control_control_command_response_pack(buffer, &msg, sizeof(buffer));
+  return makeFrame(HPO_CONTROL_CONTROL_COMMAND_RESPONSE_FRAME_ID, buffer, HPO_CONTROL_CONTROL_COMMAND_RESPONSE_LENGTH);
+}
+
+polymath::socketcan::CanFrame buildHpoErrorStatus(
+  uint8_t bus_address,
+  uint8_t subsystem_id,
+  uint8_t error_type,
+  uint16_t error_can_id,
+  uint8_t section_id,
+  uint8_t interface_id)
+{
+  hpo_error_error_status_t msg;
+  hpo_error_error_status_init(&msg);
+  msg.bus_address = bus_address;
+  msg.subsystem_id = subsystem_id;
+  msg.config_section_id = section_id;
+  msg.config_interface_id = interface_id;
+  msg.error_type = error_type;
+  msg.error_canid = error_can_id;
+  msg.crc = 0;
+
+  uint8_t buffer[CAN_MAX_DLC];
+  hpo_error_error_status_pack(buffer, &msg, sizeof(buffer));
+  msg.crc = polymath::sygnal::generate_crc8(buffer);
+  hpo_error_error_status_pack(buffer, &msg, sizeof(buffer));
+  return makeFrame(HPO_ERROR_ERROR_STATUS_FRAME_ID, buffer, HPO_ERROR_ERROR_STATUS_LENGTH);
+}
+
+}  // namespace
+
+TEST_CASE("SygnalHpoInterface default constructor zeroes interface bits", "[sygnal_hpo_interface]")
+{
+  SygnalHpoInterface hpo;
+  REQUIRE(hpo.get_bus_address() == 0);
+  REQUIRE_FALSE(hpo.get_overall_interface_state());
+  for (bool state : hpo.get_interface_states()) {
+    REQUIRE_FALSE(state);
+  }
+}
+
+TEST_CASE("SygnalHpoInterface explicit constructor sets bus address", "[sygnal_hpo_interface]")
+{
+  SygnalHpoInterface hpo(TEST_BUS_ADDRESS);
+  REQUIRE(hpo.get_bus_address() == TEST_BUS_ADDRESS);
+  REQUIRE_FALSE(hpo.get_overall_interface_state());
+  for (bool state : hpo.get_interface_states()) {
+    REQUIRE_FALSE(state);
+  }
+}
+
+TEST_CASE("SygnalHpoInterface parses heartbeat with all interfaces under HPO control", "[sygnal_hpo_interface]")
+{
+  SygnalHpoInterface hpo(TEST_BUS_ADDRESS);
+  std::array<bool, HPO_NUM_INTERFACES> interfaces{true, true, true, true, true, true, true};
+  auto frame = buildHpoHeartbeat(TEST_BUS_ADDRESS, interfaces, true);
+
+  REQUIRE(hpo.parseHeartbeatFrame(frame));
+  REQUIRE(hpo.get_overall_interface_state());
+  for (bool state : hpo.get_interface_states()) {
+    REQUIRE(state);
+  }
+}
+
+TEST_CASE("SygnalHpoInterface parses heartbeat with mixed interface bits", "[sygnal_hpo_interface]")
+{
+  SygnalHpoInterface hpo(TEST_BUS_ADDRESS);
+  std::array<bool, HPO_NUM_INTERFACES> interfaces{true, false, true, false, true, false, true};
+  auto frame = buildHpoHeartbeat(TEST_BUS_ADDRESS, interfaces, false);
+
+  REQUIRE(hpo.parseHeartbeatFrame(frame));
+  REQUIRE_FALSE(hpo.get_overall_interface_state());
+  auto states = hpo.get_interface_states();
+  for (size_t i = 0; i < HPO_NUM_INTERFACES; ++i) {
+    REQUIRE(states[i] == interfaces[i]);
+  }
+}
+
+TEST_CASE("SygnalHpoInterface rejects heartbeat with wrong frame ID", "[sygnal_hpo_interface]")
+{
+  SygnalHpoInterface hpo(TEST_BUS_ADDRESS);
+  std::array<bool, HPO_NUM_INTERFACES> interfaces{true, true, true, true, true, true, true};
+  auto frame = buildHpoHeartbeat(TEST_BUS_ADDRESS, interfaces, true);
+  frame.set_can_id(0x999);
+
+  REQUIRE_FALSE(hpo.parseHeartbeatFrame(frame));
+  REQUIRE_FALSE(hpo.get_overall_interface_state());
+}
+
+TEST_CASE("SygnalHpoInterface rejects heartbeat with bad CRC", "[sygnal_hpo_interface]")
+{
+  SygnalHpoInterface hpo(TEST_BUS_ADDRESS);
+  std::array<bool, HPO_NUM_INTERFACES> interfaces{true, true, true, true, true, true, true};
+  auto frame = buildHpoHeartbeat(TEST_BUS_ADDRESS, interfaces, true);
+
+  // Corrupt the CRC byte.
+  auto bytes = frame.get_data();
+  bytes[7] ^= 0xFF;
+  frame.set_data(bytes);
+
+  REQUIRE_FALSE(hpo.parseHeartbeatFrame(frame));
+}
+
+TEST_CASE("SygnalHpoInterface rejects heartbeat addressed to a different bus", "[sygnal_hpo_interface]")
+{
+  SygnalHpoInterface hpo(TEST_BUS_ADDRESS);
+  std::array<bool, HPO_NUM_INTERFACES> interfaces{true, true, true, true, true, true, true};
+  auto frame = buildHpoHeartbeat(OTHER_BUS_ADDRESS, interfaces, true);
+
+  REQUIRE_FALSE(hpo.parseHeartbeatFrame(frame));
+  REQUIRE_FALSE(hpo.get_overall_interface_state());
+}
+
+TEST_CASE("SygnalHpoInterface creates a ControlEnable frame addressed to itself", "[sygnal_hpo_interface]")
+{
+  SygnalHpoInterface hpo(TEST_BUS_ADDRESS);
+  std::string error_message;
+
+  auto frame_opt = hpo.createControlEnableFrame(0x42, true, error_message);
+  REQUIRE(frame_opt.has_value());
+  REQUIRE(error_message.empty());
+
+  auto frame = *frame_opt;
+  REQUIRE(frame.get_id() == HPO_CONTROL_CONTROL_ENABLE_FRAME_ID);
+  REQUIRE(frame.get_len() == HPO_CONTROL_CONTROL_ENABLE_LENGTH);
+
+  auto bytes = frame.get_data();
+  REQUIRE(polymath::sygnal::check_crc8(reinterpret_cast<uint8_t *>(bytes.data())));
+
+  hpo_control_control_enable_t unpacked;
+  hpo_control_control_enable_init(&unpacked);
+  REQUIRE(
+    hpo_control_control_enable_unpack(
+      &unpacked, reinterpret_cast<uint8_t *>(bytes.data()), HPO_CONTROL_CONTROL_ENABLE_LENGTH) == 0);
+
+  REQUIRE(unpacked.bus_address == TEST_BUS_ADDRESS);
+  REQUIRE(unpacked.message_id == 0x42);
+  REQUIRE(unpacked.enable == 1);
+}
+
+TEST_CASE("SygnalHpoInterface creates a ControlCommand frame addressed to itself", "[sygnal_hpo_interface]")
+{
+  SygnalHpoInterface hpo(TEST_BUS_ADDRESS);
+  std::string error_message;
+
+  auto frame_opt = hpo.createControlCommandFrame(0x07, 0.5, error_message);
+  REQUIRE(frame_opt.has_value());
+  REQUIRE(error_message.empty());
+
+  auto frame = *frame_opt;
+  REQUIRE(frame.get_id() == HPO_CONTROL_CONTROL_COMMAND_FRAME_ID);
+  REQUIRE(frame.get_len() == HPO_CONTROL_CONTROL_COMMAND_LENGTH);
+
+  auto bytes = frame.get_data();
+  REQUIRE(polymath::sygnal::check_crc8(reinterpret_cast<uint8_t *>(bytes.data())));
+
+  hpo_control_control_command_t unpacked;
+  hpo_control_control_command_init(&unpacked);
+  REQUIRE(
+    hpo_control_control_command_unpack(
+      &unpacked, reinterpret_cast<uint8_t *>(bytes.data()), HPO_CONTROL_CONTROL_COMMAND_LENGTH) == 0);
+
+  REQUIRE(unpacked.bus_address == TEST_BUS_ADDRESS);
+  REQUIRE(unpacked.message_id == 0x07);
+  REQUIRE(unpacked.count8 == 0);
+  const double decoded_value = hpo_control_control_command_value_decode(unpacked.value);
+  REQUIRE(std::fabs(decoded_value - 0.5) < 1e-6);
+}
+
+TEST_CASE("SygnalHpoInterface parses ControlEnableResponse", "[sygnal_hpo_interface]")
+{
+  SygnalHpoInterface hpo(TEST_BUS_ADDRESS);
+  auto frame = buildHpoControlEnableResponse(TEST_BUS_ADDRESS, 0x42, true);
+
+  auto response = hpo.parseControlResponse(frame);
+  REQUIRE(response.has_value());
+  REQUIRE(response->is_enable_response);
+  REQUIRE(response->bus_address == TEST_BUS_ADDRESS);
+  REQUIRE(response->message_id == 0x42);
+  REQUIRE(response->enable);
+}
+
+TEST_CASE("SygnalHpoInterface parses ControlCommandResponse", "[sygnal_hpo_interface]")
+{
+  SygnalHpoInterface hpo(TEST_BUS_ADDRESS);
+  auto frame = buildHpoControlCommandResponse(TEST_BUS_ADDRESS, 0x07, 0.75);
+
+  auto response = hpo.parseControlResponse(frame);
+  REQUIRE(response.has_value());
+  REQUIRE_FALSE(response->is_enable_response);
+  REQUIRE(response->bus_address == TEST_BUS_ADDRESS);
+  REQUIRE(response->message_id == 0x07);
+  REQUIRE(std::fabs(response->value - 0.75) < 1e-6);
+}
+
+TEST_CASE("SygnalHpoInterface rejects control response for a different bus", "[sygnal_hpo_interface]")
+{
+  SygnalHpoInterface hpo(TEST_BUS_ADDRESS);
+  auto frame = buildHpoControlEnableResponse(OTHER_BUS_ADDRESS, 0x42, true);
+
+  REQUIRE_FALSE(hpo.parseControlResponse(frame).has_value());
+}
+
+TEST_CASE("SygnalHpoInterface rejects control response with unrelated frame ID", "[sygnal_hpo_interface]")
+{
+  SygnalHpoInterface hpo(TEST_BUS_ADDRESS);
+  auto frame = buildHpoControlEnableResponse(TEST_BUS_ADDRESS, 0x42, true);
+  frame.set_can_id(0x999);
+
+  REQUIRE_FALSE(hpo.parseControlResponse(frame).has_value());
+}
+
+TEST_CASE("SygnalHpoInterface rejects control response with bad CRC", "[sygnal_hpo_interface]")
+{
+  SygnalHpoInterface hpo(TEST_BUS_ADDRESS);
+  auto frame = buildHpoControlCommandResponse(TEST_BUS_ADDRESS, 0x07, 0.5);
+  auto bytes = frame.get_data();
+  bytes[7] ^= 0xFF;
+  frame.set_data(bytes);
+
+  REQUIRE_FALSE(hpo.parseControlResponse(frame).has_value());
+}
+
+TEST_CASE("SygnalHpoInterface parses ErrorStatus", "[sygnal_hpo_interface]")
+{
+  SygnalHpoInterface hpo(TEST_BUS_ADDRESS);
+  auto frame = buildHpoErrorStatus(TEST_BUS_ADDRESS, 1, 5, 0x1234, 6, 2);
+
+  auto err = hpo.parseErrorFrame(frame);
+  REQUIRE(err.has_value());
+  REQUIRE(err->bus_address == TEST_BUS_ADDRESS);
+  REQUIRE(err->subsystem_id == 1);
+  REQUIRE(err->error_type == 5);
+  REQUIRE(err->error_can_id == 0x1234);
+  REQUIRE(err->config_section_id == 6);
+  REQUIRE(err->config_interface_id == 2);
+}
+
+TEST_CASE("SygnalHpoInterface rejects error frame for a different bus", "[sygnal_hpo_interface]")
+{
+  SygnalHpoInterface hpo(TEST_BUS_ADDRESS);
+  auto frame = buildHpoErrorStatus(OTHER_BUS_ADDRESS, 1, 5, 0x1234, 6, 2);
+
+  REQUIRE_FALSE(hpo.parseErrorFrame(frame).has_value());
+}
+
+TEST_CASE("SygnalHpoInterface rejects error frame with bad CRC", "[sygnal_hpo_interface]")
+{
+  SygnalHpoInterface hpo(TEST_BUS_ADDRESS);
+  auto frame = buildHpoErrorStatus(TEST_BUS_ADDRESS, 1, 5, 0x1234, 6, 2);
+  auto bytes = frame.get_data();
+  bytes[7] ^= 0xFF;
+  frame.set_data(bytes);
+
+  REQUIRE_FALSE(hpo.parseErrorFrame(frame).has_value());
+}


### PR DESCRIPTION
First pass at HPO handling. Updated to account for new DBCs structure from sygnal for HPO boards at sygnal/sygnal_can_interface/database/hpo/ . Removed state handling for HPO boards as they do not hold state like MCMs do. Deferred work on sygnal_interface_socketcan and ROS2 node to a separate commit. 

Design guidance: [https://www.notion.so/polymathrobotics/Engineering-Design-Documents-120c0b1ac5fa80dba603d41cdd11ed7e?p=366c0b1ac5fa804a82aeeae1a36375b5&pm=s&utm_content=366c0b1a-c5fa-804a-82ae-eae1a36375b5&utm_campaign=T02C9VDRBDJ&n=slack&n=slack_link_unfurl&pvs=6](url)