### PR TITLE
fix mcm relay control function

### DIFF
--- a/sygnal_can_interface/sygnal_can_interface_lib/include/sygnal_can_interface_lib/sygnal_interface_socketcan.hpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/include/sygnal_can_interface_lib/sygnal_interface_socketcan.hpp
@@ -177,7 +177,7 @@ public:
   /// @param error_message Populated on failure
   /// @return Result with success flag and optional response future
   SendCommandResult sendRelayCommand(
-    InterfaceEndpoint interface, bool relay_state, bool expect_reply, std::string & error_message);
+    RelayEndpoint relay, bool relay_state, bool expect_reply, std::string & error_message);
 
   /// @brief Send an HPO ControlEnable command.
   /// @param bus_id Bus address of the target HPO. Must match one of the hpo_ids passed at construction.

--- a/sygnal_can_interface/sygnal_can_interface_lib/src/sygnal_interface_socketcan.cpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/src/sygnal_interface_socketcan.cpp
@@ -288,9 +288,9 @@ SendCommandResult SygnalInterfaceSocketcan::sendRelayCommand(
 }
 
 SendCommandResult SygnalInterfaceSocketcan::sendRelayCommand(
-  InterfaceEndpoint interface, bool relay_state, bool expect_reply, std::string & error_message)
+  RelayEndpoint relay, bool relay_state, bool expect_reply, std::string & error_message)
 {
-  return sendRelayCommand(interface.bus_id, interface.subsystem_id, relay_state, expect_reply, error_message);
+  return sendRelayCommand(relay.bus_id, relay.subsystem_id, relay_state, expect_reply, error_message);
 }
 
 SendHpoCommandResult SygnalInterfaceSocketcan::sendHpoControlEnable(


### PR DESCRIPTION
Hot fix to have `sendRelayCommand()` take in a `RelayEndpoint` as intended, not an `InterfaceEndpoint`