### PR TITLE
fix ordering in HpoControlResponse struct in hpo_interface header

### DIFF
--- a/sygnal_can_interface/sygnal_can_interface_lib/include/sygnal_can_interface_lib/sygnal_hpo_interface.hpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/include/sygnal_can_interface_lib/sygnal_hpo_interface.hpp
@@ -36,8 +36,8 @@ constexpr uint8_t HPO_NUM_INTERFACES = 5;
 ///        the `value` field carries the float command response.
 struct HpoControlResponse
 {
-  uint8_t message_id;
   uint8_t bus_address;
+  uint8_t message_id;
   double value;
   bool enable;
   bool is_enable_response;


### PR DESCRIPTION
Message ID and Bus ID swapped in hpo_interface HpoControlResponse header, HPO on sygnal side becomes enable, but our response parsing shows disabled, addressed in this change.