### PR TITLE
update sygnal_can_interface for handling HPO state feedback according…

### DIFF
--- a/sygnal_can_interface/sygnal_can_interface_lib/include/sygnal_can_interface_lib/sygnal_hpo_interface.hpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/include/sygnal_can_interface_lib/sygnal_hpo_interface.hpp
@@ -25,10 +25,10 @@
 namespace polymath::sygnal
 {
 
-// HPO hardware exposes 5 interfaces (0-4). The DBC defines 7 signals (0-6) but the
-// remaining two are unused / always zero on real boards; we ignore them, mirroring the
-// same DBC-vs-hardware mismatch already handled by the MCM heartbeat parser.
-constexpr uint8_t HPO_NUM_INTERFACES = 5;
+// HPO hardware exposes 4 interfaces (0-3). The heartbeat reports a 1-bit control-state per
+// interface (Interface{N}State) plus a 2-bit pin-pull value (Interface{N}Value:
+// HiZ/Pull_Down/Pull_Up); the pull values are not yet surfaced (TODO: vehicleFeedback).
+constexpr uint8_t HPO_NUM_INTERFACES = 4;
 
 /// @brief Parsed HPO ControlEnableResponse / ControlCommandResponse.
 ///        is_enable_response disambiguates which payload is meaningful:
@@ -56,15 +56,15 @@ struct HpoErrorStatus
 
 /// @brief Self-contained HPO board representation.
 ///
-/// Owns the per-device interface bits (7 per-interface + 1 overall) and produces /
+/// Owns the per-interface control-state bits (one per HPO interface, 0-3) and produces /
 /// consumes the CAN frames the HPO understands. Frames are routed to the right
 /// instance by `bus_address_`: every parse helper rejects frames that do not match
 /// this device's bus address. Command frames are populated with `bus_address_`
 /// automatically so callers cannot mismatch addresses.
 ///
-/// Unlike the MCM, the HPO does not hold a Sygnal state machine. The per-interface
-/// and overall-interface heartbeat signals are 1-bit booleans (true = HPO in control,
-/// false = released). The MCM's SystemState byte is not tracked here.
+/// Unlike the MCM, the HPO does not hold a Sygnal state machine. Each per-interface
+/// heartbeat signal is a 1-bit boolean (true = HPO in control, false = released). The
+/// MCM's SystemState byte is not tracked here.
 class SygnalHpoInterface
 {
 public:
@@ -114,11 +114,6 @@ public:
     return hpo_interface_states_;
   }
 
-  bool get_overall_interface_state() const
-  {
-    return hpo_overall_interface_state_;
-  }
-
   std::chrono::system_clock::time_point get_last_heartbeat_timestamp() const
   {
     return last_heartbeat_timestamp_;
@@ -127,7 +122,6 @@ public:
 private:
   uint8_t bus_address_;
   std::array<bool, HPO_NUM_INTERFACES> hpo_interface_states_;
-  bool hpo_overall_interface_state_;
   std::chrono::system_clock::time_point last_heartbeat_timestamp_;
 };
 

--- a/sygnal_can_interface/sygnal_can_interface_lib/include/sygnal_can_interface_lib/sygnal_interface_socketcan.hpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/include/sygnal_can_interface_lib/sygnal_interface_socketcan.hpp
@@ -203,10 +203,6 @@ public:
   /// @return std::nullopt if no HPO with this bus_address has been registered.
   std::optional<std::array<bool, HPO_NUM_INTERFACES>> get_hpo_interface_states(uint8_t bus_address) const;
 
-  /// @brief Read the cached overall interface bit from the named HPO's latest heartbeat.
-  /// @return std::nullopt if no HPO with this bus_address has been registered.
-  std::optional<bool> get_hpo_overall_interface_state(uint8_t bus_address) const;
-
 private:
   std::shared_ptr<socketcan::SocketcanAdapter> socketcan_adapter_;
   std::vector<SygnalMcmInterface> mcms_;

--- a/sygnal_can_interface/sygnal_can_interface_lib/src/sygnal_hpo_interface.cpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/src/sygnal_hpo_interface.cpp
@@ -28,14 +28,12 @@ namespace polymath::sygnal
 
 SygnalHpoInterface::SygnalHpoInterface()
 : bus_address_(0)
-, hpo_overall_interface_state_(false)
 {
   hpo_interface_states_.fill(false);
 }
 
 SygnalHpoInterface::SygnalHpoInterface(uint8_t bus_address)
 : bus_address_(bus_address)
-, hpo_overall_interface_state_(false)
 {
   hpo_interface_states_.fill(false);
 }
@@ -71,9 +69,7 @@ bool SygnalHpoInterface::parseHeartbeatFrame(const socketcan::CanFrame & frame)
   hpo_interface_states_[1] = (0 != unpacked.interface1_state);
   hpo_interface_states_[2] = (0 != unpacked.interface2_state);
   hpo_interface_states_[3] = (0 != unpacked.interface3_state);
-  hpo_interface_states_[4] = (0 != unpacked.interface4_state);
-  // Signals interface5_state / interface6_state are present in the DBC but unused on real HPO hardware.
-  hpo_overall_interface_state_ = (0 != unpacked.overall_interface_state);
+  // Interface{0-3}Value (2-bit pin-pull: HiZ/Pull_Down/Pull_Up) are also in this frame, not yet surfaced.
 
   return true;
 }

--- a/sygnal_can_interface/sygnal_can_interface_lib/src/sygnal_interface_socketcan.cpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/src/sygnal_interface_socketcan.cpp
@@ -377,15 +377,4 @@ std::optional<std::array<bool, HPO_NUM_INTERFACES>> SygnalInterfaceSocketcan::ge
   return it->get_interface_states();
 }
 
-std::optional<bool> SygnalInterfaceSocketcan::get_hpo_overall_interface_state(uint8_t bus_address) const
-{
-  auto it = std::find_if(hpos_.begin(), hpos_.end(), [bus_address](const SygnalHpoInterface & h) {
-    return h.get_bus_address() == bus_address;
-  });
-  if (it == hpos_.end()) {
-    return std::nullopt;
-  }
-  return it->get_overall_interface_state();
-}
-
 }  // namespace polymath::sygnal

--- a/sygnal_can_interface/sygnal_can_interface_lib/test/sygnal_hpo_interface_test.cpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/test/sygnal_hpo_interface_test.cpp
@@ -59,7 +59,7 @@ polymath::socketcan::CanFrame makeFrame(uint32_t can_id, const uint8_t * data, u
 }
 
 polymath::socketcan::CanFrame buildHpoHeartbeat(
-  uint8_t bus_address, const std::array<bool, HPO_NUM_INTERFACES> & interface_states, bool overall_state)
+  uint8_t bus_address, const std::array<bool, HPO_NUM_INTERFACES> & interface_states)
 {
   hpo_heartbeat_heartbeat_t msg;
   hpo_heartbeat_heartbeat_init(&msg);
@@ -70,10 +70,6 @@ polymath::socketcan::CanFrame buildHpoHeartbeat(
   msg.interface1_state = interface_states[1] ? 1 : 0;
   msg.interface2_state = interface_states[2] ? 1 : 0;
   msg.interface3_state = interface_states[3] ? 1 : 0;
-  msg.interface4_state = interface_states[4] ? 1 : 0;
-  msg.interface5_state = 0;
-  msg.interface6_state = 0;
-  msg.overall_interface_state = overall_state ? 1 : 0;
   msg.count16 = 0;
   msg.crc = 0;
 
@@ -148,7 +144,6 @@ TEST_CASE("SygnalHpoInterface default constructor zeroes interface bits", "[sygn
 {
   SygnalHpoInterface hpo;
   REQUIRE(hpo.get_bus_address() == 0);
-  REQUIRE_FALSE(hpo.get_overall_interface_state());
   for (bool state : hpo.get_interface_states()) {
     REQUIRE_FALSE(state);
   }
@@ -158,7 +153,6 @@ TEST_CASE("SygnalHpoInterface explicit constructor sets bus address", "[sygnal_h
 {
   SygnalHpoInterface hpo(TEST_BUS_ADDRESS);
   REQUIRE(hpo.get_bus_address() == TEST_BUS_ADDRESS);
-  REQUIRE_FALSE(hpo.get_overall_interface_state());
   for (bool state : hpo.get_interface_states()) {
     REQUIRE_FALSE(state);
   }
@@ -167,11 +161,10 @@ TEST_CASE("SygnalHpoInterface explicit constructor sets bus address", "[sygnal_h
 TEST_CASE("SygnalHpoInterface parses heartbeat with all interfaces under HPO control", "[sygnal_hpo_interface]")
 {
   SygnalHpoInterface hpo(TEST_BUS_ADDRESS);
-  std::array<bool, HPO_NUM_INTERFACES> interfaces{true, true, true, true, true};
-  auto frame = buildHpoHeartbeat(TEST_BUS_ADDRESS, interfaces, true);
+  std::array<bool, HPO_NUM_INTERFACES> interfaces{true, true, true, true};
+  auto frame = buildHpoHeartbeat(TEST_BUS_ADDRESS, interfaces);
 
   REQUIRE(hpo.parseHeartbeatFrame(frame));
-  REQUIRE(hpo.get_overall_interface_state());
   for (bool state : hpo.get_interface_states()) {
     REQUIRE(state);
   }
@@ -180,11 +173,10 @@ TEST_CASE("SygnalHpoInterface parses heartbeat with all interfaces under HPO con
 TEST_CASE("SygnalHpoInterface parses heartbeat with mixed interface bits", "[sygnal_hpo_interface]")
 {
   SygnalHpoInterface hpo(TEST_BUS_ADDRESS);
-  std::array<bool, HPO_NUM_INTERFACES> interfaces{true, false, true, false, true};
-  auto frame = buildHpoHeartbeat(TEST_BUS_ADDRESS, interfaces, false);
+  std::array<bool, HPO_NUM_INTERFACES> interfaces{true, false, true, false};
+  auto frame = buildHpoHeartbeat(TEST_BUS_ADDRESS, interfaces);
 
   REQUIRE(hpo.parseHeartbeatFrame(frame));
-  REQUIRE_FALSE(hpo.get_overall_interface_state());
   auto states = hpo.get_interface_states();
   for (size_t i = 0; i < HPO_NUM_INTERFACES; ++i) {
     REQUIRE(states[i] == interfaces[i]);
@@ -194,19 +186,18 @@ TEST_CASE("SygnalHpoInterface parses heartbeat with mixed interface bits", "[syg
 TEST_CASE("SygnalHpoInterface rejects heartbeat with wrong frame ID", "[sygnal_hpo_interface]")
 {
   SygnalHpoInterface hpo(TEST_BUS_ADDRESS);
-  std::array<bool, HPO_NUM_INTERFACES> interfaces{true, true, true, true, true};
-  auto frame = buildHpoHeartbeat(TEST_BUS_ADDRESS, interfaces, true);
+  std::array<bool, HPO_NUM_INTERFACES> interfaces{true, true, true, true};
+  auto frame = buildHpoHeartbeat(TEST_BUS_ADDRESS, interfaces);
   frame.set_can_id(0x999);
 
   REQUIRE_FALSE(hpo.parseHeartbeatFrame(frame));
-  REQUIRE_FALSE(hpo.get_overall_interface_state());
 }
 
 TEST_CASE("SygnalHpoInterface rejects heartbeat with bad CRC", "[sygnal_hpo_interface]")
 {
   SygnalHpoInterface hpo(TEST_BUS_ADDRESS);
-  std::array<bool, HPO_NUM_INTERFACES> interfaces{true, true, true, true, true};
-  auto frame = buildHpoHeartbeat(TEST_BUS_ADDRESS, interfaces, true);
+  std::array<bool, HPO_NUM_INTERFACES> interfaces{true, true, true, true};
+  auto frame = buildHpoHeartbeat(TEST_BUS_ADDRESS, interfaces);
 
   // Corrupt the CRC byte.
   auto bytes = frame.get_data();
@@ -219,11 +210,10 @@ TEST_CASE("SygnalHpoInterface rejects heartbeat with bad CRC", "[sygnal_hpo_inte
 TEST_CASE("SygnalHpoInterface rejects heartbeat addressed to a different bus", "[sygnal_hpo_interface]")
 {
   SygnalHpoInterface hpo(TEST_BUS_ADDRESS);
-  std::array<bool, HPO_NUM_INTERFACES> interfaces{true, true, true, true, true};
-  auto frame = buildHpoHeartbeat(OTHER_BUS_ADDRESS, interfaces, true);
+  std::array<bool, HPO_NUM_INTERFACES> interfaces{true, true, true, true};
+  auto frame = buildHpoHeartbeat(OTHER_BUS_ADDRESS, interfaces);
 
   REQUIRE_FALSE(hpo.parseHeartbeatFrame(frame));
-  REQUIRE_FALSE(hpo.get_overall_interface_state());
 }
 
 TEST_CASE("SygnalHpoInterface creates a ControlEnable frame addressed to itself", "[sygnal_hpo_interface]")

--- a/sygnal_can_interface/sygnal_can_interface_lib/test/sygnal_interface_socketcan_routing_test.cpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/test/sygnal_interface_socketcan_routing_test.cpp
@@ -62,7 +62,7 @@ polymath::socketcan::CanFrame makeFrame(uint32_t can_id, const uint8_t * buffer,
   return frame;
 }
 
-polymath::socketcan::CanFrame buildHpoHeartbeat(uint8_t bus_address, bool overall_state)
+polymath::socketcan::CanFrame buildHpoHeartbeat(uint8_t bus_address)
 {
   hpo_heartbeat_heartbeat_t msg;
   hpo_heartbeat_heartbeat_init(&msg);
@@ -73,8 +73,6 @@ polymath::socketcan::CanFrame buildHpoHeartbeat(uint8_t bus_address, bool overal
   msg.interface1_state = 0;
   msg.interface2_state = 1;
   msg.interface3_state = 0;
-  msg.interface4_state = 1;
-  msg.overall_interface_state = overall_state ? 1 : 0;
   msg.count16 = 0;
   msg.crc = 0;
 
@@ -164,12 +162,8 @@ TEST_CASE("parse() routes HPO heartbeat to HPO state and leaves MCM untouched", 
 
   polymath::sygnal::SygnalInterfaceSocketcan sygnal(adapter, mcms, hpos);
 
-  auto frame = buildHpoHeartbeat(HPO_BUS, /*overall_state=*/true);
+  auto frame = buildHpoHeartbeat(HPO_BUS);
   REQUIRE(sygnal.parse(frame));
-
-  auto hpo_state = sygnal.get_hpo_overall_interface_state(HPO_BUS);
-  REQUIRE(hpo_state.has_value());
-  REQUIRE(hpo_state.value());
 
   auto hpo_interfaces = sygnal.get_hpo_interface_states(HPO_BUS);
   REQUIRE(hpo_interfaces.has_value());
@@ -177,7 +171,6 @@ TEST_CASE("parse() routes HPO heartbeat to HPO state and leaves MCM untouched", 
   REQUIRE_FALSE((*hpo_interfaces)[1]);
   REQUIRE((*hpo_interfaces)[2]);
   REQUIRE_FALSE((*hpo_interfaces)[3]);
-  REQUIRE((*hpo_interfaces)[4]);
 
   // MCM state untouched: still default FAIL_HARD.
   auto mcm_state = sygnal.get_sygnal_mcm_state(MCM_BUS, 0);
@@ -200,10 +193,12 @@ TEST_CASE("parse() routes MCM heartbeat to MCM state and leaves HPO untouched", 
   REQUIRE(mcm_state.has_value());
   REQUIRE(mcm_state.value() == polymath::sygnal::SygnalSystemState::MCM_CONTROL);
 
-  // HPO overall interface state stays at the default false.
-  auto hpo_state = sygnal.get_hpo_overall_interface_state(HPO_BUS);
-  REQUIRE(hpo_state.has_value());
-  REQUIRE_FALSE(hpo_state.value());
+  // HPO interface states stay at their default false.
+  auto hpo_interfaces = sygnal.get_hpo_interface_states(HPO_BUS);
+  REQUIRE(hpo_interfaces.has_value());
+  for (bool state : *hpo_interfaces) {
+    REQUIRE_FALSE(state);
+  }
 }
 
 TEST_CASE(

--- a/sygnal_dbc/database/hpo/Heartbeat.dbc
+++ b/sygnal_dbc/database/hpo/Heartbeat.dbc
@@ -2,135 +2,135 @@ VERSION ""
 
 
 NS_ :
-	NS_DESC_
-	CM_
-	BA_DEF_
-	BA_
-	VAL_
-	CAT_DEF_
-	CAT_
-	FILTER
-	BA_DEF_DEF_
-	EV_DATA_
-	ENVVAR_DATA_
-	SGTYPE_
-	SGTYPE_VAL_
-	BA_DEF_SGTYPE_
-	BA_SGTYPE_
-	SIG_TYPE_REF_
-	VAL_TABLE_
-	SIG_GROUP_
-	SIG_VALTYPE_
-	SIGTYPE_VALTYPE_
-	BO_TX_BU_
-	BA_DEF_REL_
-	BA_REL_
-	BA_DEF_DEF_REL_
-	BU_SG_REL_
-	BU_EV_REL_
-	BU_BO_REL_
-	SG_MUL_VAL_
+    NS_DESC_
+    CM_
+    BA_DEF_
+    BA_
+    VAL_
+    CAT_DEF_
+    CAT_
+    FILTER
+    BA_DEF_DEF_
+    EV_DATA_
+    ENVVAR_DATA_
+    SGTYPE_
+    SGTYPE_VAL_
+    BA_DEF_SGTYPE_
+    BA_SGTYPE_
+    SIG_TYPE_REF_
+    VAL_TABLE_
+    SIG_GROUP_
+    SIG_VALTYPE_
+    SIGTYPE_VALTYPE_
+    BO_TX_BU_
+    BA_DEF_REL_
+    BA_REL_
+    BA_DEF_DEF_REL_
+    BU_SG_REL_
+    BU_EV_REL_
+    BU_BO_REL_
+    SG_MUL_VAL_
 
 BS_:
-
 BU_: UserApplication MCM
-VAL_TABLE_ SystemState 254 "Fail Hard" 253 "Human Override" 242 "Fail Operational 2" 241 "Fail Operational 1" 1 "MCM Control" 0 "Human Control" ;
-VAL_TABLE_ InterfaceState 1 "MCM Control" 0 "Human Control" ;
-
-
 BO_ 368 Heartbeat: 8 MCM
- SG_ OverallInterfaceState : 31|1@1+ (1,0) [0|0] "" Vector__XXX
- SG_ Interface6State : 30|1@1+ (1,0) [0|0] "" Vector__XXX
- SG_ Interface5State : 29|1@1+ (1,0) [0|0] "" Vector__XXX
- SG_ Interface4State : 28|1@1+ (1,0) [0|0] "" Vector__XXX
- SG_ Interface3State : 27|1@1+ (1,0) [0|0] "" Vector__XXX
- SG_ Interface2State : 26|1@1+ (1,0) [0|0] "" Vector__XXX
- SG_ Interface1State : 25|1@1+ (1,0) [0|0] "" Vector__XXX
- SG_ Interface0State : 24|1@1+ (1,0) [0|0] "" Vector__XXX
- SG_ SystemState : 16|8@1+ (1,0) [0|0] "" Vector__XXX
- SG_ Count16 : 40|16@1+ (1,0) [0|0] "" Vector__XXX
- SG_ CRC : 56|8@1+ (1,0) [0|0] "" Vector__XXX
- SG_ SubsystemID : 7|1@1+ (1,0) [0|0] "" Vector__XXX
- SG_ BusAddress : 0|7@1+ (1,0) [0|0] "" Vector__XXX
+   SG_ Interface3State : 27|1@1+ (1,0) [0|0] "" Vector__XXX
+   SG_ Interface2State : 26|1@1+ (1,0) [0|0] "" Vector__XXX
+   SG_ Interface1State : 25|1@1+ (1,0) [0|0] "" Vector__XXX
+   SG_ Interface0State : 24|1@1+ (1,0) [0|0] "" Vector__XXX
+   SG_ SystemState : 16|8@1+ (1,0) [0|0] "" Vector__XXX
+   SG_ Count16 : 40|16@1+ (1,0) [0|0] "" Vector__XXX
+   SG_ CRC : 56|8@1+ (1,0) [0|0] "" Vector__XXX
+   SG_ SubsystemID : 7|1@1+ (1,0) [0|0] "" Vector__XXX
+   SG_ BusAddress : 0|7@1+ (1,0) [0|0] "" Vector__XXX
+   SG_ Interface0Value : 32|2@1+ (1,0) [0|0] "" Vector__XXX
+   SG_ Interface1Value : 34|2@1+ (1,0) [0|0] "" Vector__XXX
+   SG_ Interface2Value : 36|2@1+ (1,0) [0|0] "" Vector__XXX
+   SG_ Interface3Value : 38|2@1+ (1,0) [0|0] "" Vector__XXX
 
-
-
-BA_DEF_ BO_  "TpJ1939VarDlc" ENUM  "No","Yes";
-BA_DEF_ SG_  "SigType" ENUM  "Default","Range","RangeSigned","ASCII","Discrete","Control","ReferencePGN","DTC","StringDelimiter","StringLength","StringLengthControl","MessageCounter","MessageChecksum";
-BA_DEF_ SG_  "GenSigEVName" STRING ;
-BA_DEF_ SG_  "GenSigILSupport" ENUM  "No","Yes";
-BA_DEF_ SG_  "GenSigSendType" ENUM  "Cyclic","OnWrite","OnWriteWithRepetition","OnChange","OnChangeWithRepetition","IfActive","IfActiveWithRepetition","NoSigSendType";
-BA_DEF_ BO_  "GenMsgFastOnStart" INT 0 100000;
-BA_DEF_ SG_  "GenSigInactiveValue" INT 0 0;
-BA_DEF_ BO_  "GenMsgCycleTimeFast" INT 0 3600000;
-BA_DEF_ BO_  "GenMsgNrOfRepetition" INT 0 1000000;
-BA_DEF_ SG_  "GenSigStartValue" INT 0 2147483647;
-BA_DEF_ BO_  "GenMsgDelayTime" INT 0 1000;
-BA_DEF_ BO_  "GenMsgILSupport" ENUM  "No","Yes";
-BA_DEF_ BO_  "GenMsgStartDelayTime" INT 0 100000;
-BA_DEF_ BU_  "NodeLayerModules" STRING ;
-BA_DEF_ BU_  "ECU" STRING ;
-BA_DEF_ BU_  "NmJ1939SystemInstance" INT 0 15;
-BA_DEF_ BU_  "NmJ1939System" INT 0 127;
-BA_DEF_ BU_  "NmJ1939ManufacturerCode" INT 0 2047;
-BA_DEF_ BU_  "NmJ1939IndustryGroup" INT 0 7;
-BA_DEF_ BU_  "NmJ1939IdentityNumber" INT 0 2097151;
-BA_DEF_ BU_  "NmJ1939FunctionInstance" INT 0 7;
-BA_DEF_ BU_  "NmJ1939Function" INT 0 255;
-BA_DEF_ BU_  "NmJ1939ECUInstance" INT 0 3;
-BA_DEF_ BU_  "NmJ1939AAC" INT 0 1;
-BA_DEF_ BU_  "NmStationAddress" INT 0 255;
-BA_DEF_ BO_  "GenMsgSendType" ENUM  "cyclic","NotUsed","IfActive","NotUsed","NotUsed","NotUsed","NotUsed","NotUsed","noMsgSendType";
-BA_DEF_ BO_  "GenMsgRequestable" INT 0 1;
-BA_DEF_ BO_  "GenMsgCycleTime" INT 0 3600000;
-BA_DEF_ SG_  "SPN" INT 0 524287;
-BA_DEF_  "DBName" STRING ;
-BA_DEF_  "BusType" STRING ;
-BA_DEF_  "ProtocolType" STRING ;
-BA_DEF_ BO_  "VFrameFormat" ENUM  "StandardCAN","ExtendedCAN","reserved","J1939PG";
-BA_DEF_DEF_  "TpJ1939VarDlc" "No";
-BA_DEF_DEF_  "SigType" "Default";
-BA_DEF_DEF_  "GenSigEVName" "Env@Nodename_@Signame";
-BA_DEF_DEF_  "GenSigILSupport" "Yes";
-BA_DEF_DEF_  "GenSigSendType" "NoSigSendType";
-BA_DEF_DEF_  "GenMsgFastOnStart" 0;
-BA_DEF_DEF_  "GenSigInactiveValue" 0;
-BA_DEF_DEF_  "GenMsgCycleTimeFast" 0;
-BA_DEF_DEF_  "GenMsgNrOfRepetition" 0;
-BA_DEF_DEF_  "GenSigStartValue" 0;
-BA_DEF_DEF_  "GenMsgDelayTime" 0;
-BA_DEF_DEF_  "GenMsgILSupport" "Yes";
-BA_DEF_DEF_  "GenMsgStartDelayTime" 0;
-BA_DEF_DEF_  "NodeLayerModules" "";
-BA_DEF_DEF_  "ECU" "";
-BA_DEF_DEF_  "NmJ1939SystemInstance" 0;
-BA_DEF_DEF_  "NmJ1939System" 0;
-BA_DEF_DEF_  "NmJ1939ManufacturerCode" 0;
-BA_DEF_DEF_  "NmJ1939IndustryGroup" 0;
-BA_DEF_DEF_  "NmJ1939IdentityNumber" 0;
-BA_DEF_DEF_  "NmJ1939FunctionInstance" 0;
-BA_DEF_DEF_  "NmJ1939Function" 0;
-BA_DEF_DEF_  "NmJ1939ECUInstance" 0;
-BA_DEF_DEF_  "NmJ1939AAC" 0;
-BA_DEF_DEF_  "NmStationAddress" 254;
-BA_DEF_DEF_  "GenMsgSendType" "noMsgSendType";
-BA_DEF_DEF_  "GenMsgRequestable" 1;
-BA_DEF_DEF_  "GenMsgCycleTime" 0;
-BA_DEF_DEF_  "SPN" 0;
-BA_DEF_DEF_  "DBName" "";
-BA_DEF_DEF_  "BusType" "CAN";
-BA_DEF_DEF_  "ProtocolType" "J1939";
-BA_DEF_DEF_  "VFrameFormat" "J1939PG";
-BA_ "DBName" "Sygnal";
+BA_DEF_ BO_ "TpJ1939VarDlc" ENUM "No","Yes";
+BA_DEF_ SG_ "SigType" ENUM "No","Yes","Default","Range","RangeSigned","ASCII","Discrete","Control","ReferencePGN","DTC","StringDelimiter","StringLength","StringLengthControl","MessageCounter","MessageChecksum";
+BA_DEF_ SG_ "GenSigEVName" STRING ;
+BA_DEF_ SG_ "GenSigILSupport" ENUM "No","Yes","Default","Range","RangeSigned","ASCII","Discrete","Control","ReferencePGN","DTC","StringDelimiter","StringLength","StringLengthControl","MessageCounter","MessageChecksum","No","Yes";
+BA_DEF_ SG_ "GenSigSendType" ENUM "No","Yes","Default","Range","RangeSigned","ASCII","Discrete","Control","ReferencePGN","DTC","StringDelimiter","StringLength","StringLengthControl","MessageCounter","MessageChecksum","No","Yes","Cyclic","OnWrite","OnWriteWithRepetition","OnChange","OnChangeWithRepetition","IfActive","IfActiveWithRepetition","NoSigSendType";
+BA_DEF_ BO_ "GenMsgFastOnStart" INT 0 100000;
+BA_DEF_ SG_ "GenSigInactiveValue" INT 0 0;
+BA_DEF_ BO_ "GenMsgCycleTimeFast" INT 0 3.6e+06;
+BA_DEF_ BO_ "GenMsgNrOfRepetition" INT 0 1e+06;
+BA_DEF_ SG_ "GenSigStartValue" INT 0 2.14748e+09;
+BA_DEF_ BO_ "GenMsgDelayTime" INT 0 1000;
+BA_DEF_ BO_ "GenMsgILSupport" ENUM "No","Yes","Default","Range","RangeSigned","ASCII","Discrete","Control","ReferencePGN","DTC","StringDelimiter","StringLength","StringLengthControl","MessageCounter","MessageChecksum","No","Yes","Cyclic","OnWrite","OnWriteWithRepetition","OnChange","OnChangeWithRepetition","IfActive","IfActiveWithRepetition","NoSigSendType","No","Yes";
+BA_DEF_ BO_ "GenMsgStartDelayTime" INT 0 100000;
+BA_DEF_ BU_ "NodeLayerModules" STRING ;
+BA_DEF_ BU_ "ECU" STRING ;
+BA_DEF_ BU_ "NmJ1939SystemInstance" INT 0 15;
+BA_DEF_ BU_ "NmJ1939System" INT 0 127;
+BA_DEF_ BU_ "NmJ1939ManufacturerCode" INT 0 2047;
+BA_DEF_ BU_ "NmJ1939IndustryGroup" INT 0 7;
+BA_DEF_ BU_ "NmJ1939IdentityNumber" INT 0 2.09715e+06;
+BA_DEF_ BU_ "NmJ1939FunctionInstance" INT 0 7;
+BA_DEF_ BU_ "NmJ1939Function" INT 0 255;
+BA_DEF_ BU_ "NmJ1939ECUInstance" INT 0 3;
+BA_DEF_ BU_ "NmJ1939AAC" INT 0 1;
+BA_DEF_ BU_ "NmStationAddress" INT 0 255;
+BA_DEF_ BO_ "GenMsgSendType" ENUM "No","Yes","Default","Range","RangeSigned","ASCII","Discrete","Control","ReferencePGN","DTC","StringDelimiter","StringLength","StringLengthControl","MessageCounter","MessageChecksum","No","Yes","Cyclic","OnWrite","OnWriteWithRepetition","OnChange","OnChangeWithRepetition","IfActive","IfActiveWithRepetition","NoSigSendType","No","Yes","cyclic","NotUsed","IfActive","NotUsed","NotUsed","NotUsed","NotUsed","NotUsed","noMsgSendType";
+BA_DEF_ BO_ "GenMsgRequestable" INT 0 1;
+BA_DEF_ BO_ "GenMsgCycleTime" INT 0 3.6e+06;
+BA_DEF_ SG_ "SPN" INT 0 524287;
+BA_DEF_ "DBName" STRING ;
+BA_DEF_ "BusType" STRING ;
+BA_DEF_ "ProtocolType" STRING ;
+BA_DEF_ BO_ "VFrameFormat" ENUM "No","Yes","Default","Range","RangeSigned","ASCII","Discrete","Control","ReferencePGN","DTC","StringDelimiter","StringLength","StringLengthControl","MessageCounter","MessageChecksum","No","Yes","Cyclic","OnWrite","OnWriteWithRepetition","OnChange","OnChangeWithRepetition","IfActive","IfActiveWithRepetition","NoSigSendType","No","Yes","cyclic","NotUsed","IfActive","NotUsed","NotUsed","NotUsed","NotUsed","NotUsed","noMsgSendType","StandardCAN","ExtendedCAN","reserved","J1939PG";
+BA_DEF_ BO_ "GenMsgBackgroundColor" STRING ;
+BA_DEF_ BO_ "GenMsgForegroundColor" STRING ;
+BA_DEF_ BO_ "matchingcriteria" INT 0 0;
+BA_DEF_ BO_ "filterlabeling" INT 0 0;
 BA_ "NmStationAddress" BU_ UserApplication 241;
 BA_ "NmStationAddress" BU_ MCM 0;
 BA_ "VFrameFormat" BO_ 368 0;
-VAL_ 368 OverallInterfaceState 1 "MCM Control" 0 "Human Control" ;
-VAL_ 368 Interface6State 1 "MCM Control" 0 "Human Control" ;
-VAL_ 368 Interface5State 1 "MCM Control" 0 "Human Control" ;
-VAL_ 368 Interface4State 1 "MCM Control" 0 "Human Control" ;
-VAL_ 368 Interface3State 1 "MCM Control" 0 "Human Control" ;
-VAL_ 368 Interface2State 1 "MCM Control" 0 "Human Control" ;
-VAL_ 368 Interface1State 1 "MCM Control" 0 "Human Control" ;
-VAL_ 368 Interface0State 1 "MCM Control" 0 "Human Control" ;
-VAL_ 368 SystemState 254 "Fail Hard" 253 "Human Override" 242 "Fail Operational 2" 241 "Fail Operational 1" 1 "MCM Control" 0 "Human Control" ;
+BA_DEF_DEF_ "TpJ1939VarDlc" "No";
+BA_DEF_DEF_ "SigType" "Default";
+BA_DEF_DEF_ "GenSigEVName" "Env";
+BA_DEF_DEF_ "GenSigILSupport" "Yes";
+BA_DEF_DEF_ "GenSigSendType" "NoSigSendType";
+BA_DEF_DEF_ "GenMsgFastOnStart" 0;
+BA_DEF_DEF_ "GenSigInactiveValue" 0;
+BA_DEF_DEF_ "GenMsgCycleTimeFast" 0;
+BA_DEF_DEF_ "GenMsgNrOfRepetition" 0;
+BA_DEF_DEF_ "GenSigStartValue" 0;
+BA_DEF_DEF_ "GenMsgDelayTime" 0;
+BA_DEF_DEF_ "GenMsgILSupport" "Yes";
+BA_DEF_DEF_ "GenMsgStartDelayTime" 0;
+BA_DEF_DEF_ "NodeLayerModules" "";
+BA_DEF_DEF_ "ECU" "";
+BA_DEF_DEF_ "NmJ1939SystemInstance" 0;
+BA_DEF_DEF_ "NmJ1939System" 0;
+BA_DEF_DEF_ "NmJ1939ManufacturerCode" 0;
+BA_DEF_DEF_ "NmJ1939IndustryGroup" 0;
+BA_DEF_DEF_ "NmJ1939IdentityNumber" 0;
+BA_DEF_DEF_ "NmJ1939FunctionInstance" 0;
+BA_DEF_DEF_ "NmJ1939Function" 0;
+BA_DEF_DEF_ "NmJ1939ECUInstance" 0;
+BA_DEF_DEF_ "NmJ1939AAC" 0;
+BA_DEF_DEF_ "NmStationAddress" 254;
+BA_DEF_DEF_ "GenMsgSendType" "noMsgSendType";
+BA_DEF_DEF_ "GenMsgRequestable" 1;
+BA_DEF_DEF_ "GenMsgCycleTime" 0;
+BA_DEF_DEF_ "SPN" 0;
+BA_DEF_DEF_ "DBName" "";
+BA_DEF_DEF_ "BusType" "CAN";
+BA_DEF_DEF_ "ProtocolType" "J1939";
+BA_DEF_DEF_ "VFrameFormat" "J1939PG";
+BA_DEF_DEF_ "GenMsgBackgroundColor" "#ffffff";
+BA_DEF_DEF_ "GenMsgForegroundColor" "#000000";
+BA_DEF_DEF_ "matchingcriteria" 0;
+BA_DEF_DEF_ "filterlabeling" 1;
+VAL_ 368 Interface3State 1 "MCM Control" 0 "Human Control";
+VAL_ 368 Interface2State 1 "MCM Control" 0 "Human Control";
+VAL_ 368 Interface1State 1 "MCM Control" 0 "Human Control";
+VAL_ 368 Interface0State 1 "MCM Control" 0 "Human Control";
+VAL_ 368 SystemState 254 "Fail Hard" 253 "Human Override" 242 "Fail Operational 2" 241 "Fail Operational 1" 1 "MCM Control" 0 "Human Control";
+VAL_ 368 Interface0Value 1 "Pull_Down" 0 "HiZ" 2 "Pull_Up";
+VAL_ 368 Interface1Value 1 "Pull_Down" 0 "HiZ" 2 "Pull_Up";
+VAL_ 368 Interface2Value 1 "Pull_Down" 0 "HiZ" 2 "Pull_Up";
+VAL_ 368 Interface3Value 1 "Pull_Down" 0 "HiZ" 2 "Pull_Up";


### PR DESCRIPTION
… to Heartbeat.dbc

New DBC file for HPO Heartbeat landed, which provides control state and command value feedback on top of the existing heartbeat. Required changes to sygnal_can_interface and other relevant surfaces. None of this should affect existing Sygnal vehicles as LEV05 is the only caller for HPO related logic. 