### PR TITLE
Add mcm version querying / identification

### DIFF
--- a/sygnal_can_interface/sygnal_can_interface_lib/CMakeLists.txt
+++ b/sygnal_can_interface/sygnal_can_interface_lib/CMakeLists.txt
@@ -141,6 +141,22 @@ if(BUILD_TESTING)
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
   )
 
+  add_executable(sygnal_identify_tests
+    test/sygnal_identify_test.cpp
+  )
+  target_link_libraries(sygnal_identify_tests
+    PRIVATE ${PROJECT_NAME} sygnal_dbc::sygnal_dbc Catch2::Catch2WithMain
+  )
+  ament_add_test(
+    sygnal_identify_tests
+    GENERATE_RESULT_FOR_RETURN_CODE_ZERO
+    COMMAND "$<TARGET_FILE:sygnal_identify_tests>"
+      -r junit -s
+      -o test_results/${PROJECT_NAME}/sygnal_identify_tests_output.xml
+    ENV CATCH_CONFIG_CONSOLE_WIDTH=120
+    WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+  )
+
   if(DEFINED ENV{CAN_AVAILABLE})
     add_executable(sygnal_interface_socketcan_tests
       test/sygnal_interface_socketcan_test.cpp

--- a/sygnal_can_interface/sygnal_can_interface_lib/include/sygnal_can_interface_lib/sygnal_command_interface.hpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/include/sygnal_can_interface_lib/sygnal_command_interface.hpp
@@ -96,6 +96,11 @@ public:
   std::optional<polymath::socketcan::CanFrame> createRelayCommandFrame(
     const uint8_t bus_id, const uint8_t subsystem_id, const bool relay_state, std::string & error_message);
 
+  /// @brief Create the broadcast IdentifyCommand frame. Every Sygnal device on the bus answers with
+  ///        its IdentifyResponse frames. The frame is zero-length with no addressing and no CRC.
+  /// @return can frame
+  polymath::socketcan::CanFrame createIdentifyCommandFrame();
+
   /// @brief Parse a command response frame if it is covered by this interface
   /// @param frame Raw cran frame to check and parse
   /// @return Optional, if the frame is a valid response, return the response

--- a/sygnal_can_interface/sygnal_can_interface_lib/include/sygnal_can_interface_lib/sygnal_interface_socketcan.hpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/include/sygnal_can_interface_lib/sygnal_interface_socketcan.hpp
@@ -203,6 +203,19 @@ public:
   /// @return std::nullopt if no HPO with this bus_address has been registered.
   std::optional<std::array<bool, HPO_NUM_INTERFACES>> get_hpo_interface_states(uint8_t bus_address) const;
 
+  /// @brief Broadcast an IdentifyCommand.
+  //         Every Sygnal device answers with its IdentifyResponse frames,
+  //         which parse() records into the matching MCM.
+  //         identities are read back via get_mcm_identity()
+  //         after allowing time for responses to arrive.
+  /// @param[out] error_message Populated on failure.
+  /// @return true if the command frame was sent.
+  bool sendIdentifyQuery(std::string & error_message);
+
+  /// @brief Get the recorded identity for the named MCM endpoint.
+  /// @return std::nullopt if no MCM with this bus/subsystem is registered, or none has responded yet.
+  std::optional<McmIdentity> get_mcm_identity(uint8_t bus_address, uint8_t subsystem_id) const;
+
 private:
   std::shared_ptr<socketcan::SocketcanAdapter> socketcan_adapter_;
   std::vector<SygnalMcmInterface> mcms_;

--- a/sygnal_can_interface/sygnal_can_interface_lib/include/sygnal_can_interface_lib/sygnal_mcm_interface.hpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/include/sygnal_can_interface_lib/sygnal_mcm_interface.hpp
@@ -38,7 +38,9 @@ struct SygnalVersion
 
 inline bool operator==(const SygnalVersion & a, const SygnalVersion & b)
 {
-  return a.major == b.major && a.minor == b.minor && a.patch == b.patch;
+  return a.major == b.major  // NOLINT(readability/check)
+         && a.minor == b.minor  // NOLINT(readability/check)
+         && a.patch == b.patch;
 }
 
 /// @brief Identity and firmware versions of one MCM, assembled from its three IdentifyResponse
@@ -59,9 +61,14 @@ struct McmIdentity
 
 inline bool operator==(const McmIdentity & a, const McmIdentity & b)
 {
-  return a.module_serial_number == b.module_serial_number && a.product_id == b.product_id &&
-         a.module_boot_state == b.module_boot_state && a.app_version == b.app_version && a.bl_version == b.bl_version &&
-         a.has_main == b.has_main && a.has_app_version == b.has_app_version && a.has_bl_version == b.has_bl_version;
+  return a.module_serial_number == b.module_serial_number  // NOLINT(readability/check)
+         && a.product_id == b.product_id  // NOLINT(readability/check)
+         && a.module_boot_state == b.module_boot_state  // NOLINT(readability/check)
+         && a.app_version == b.app_version  // NOLINT(readability/check)
+         && a.bl_version == b.bl_version  // NOLINT(readability/check)
+         && a.has_main == b.has_main  // NOLINT(readability/check)
+         && a.has_app_version == b.has_app_version  // NOLINT(readability/check)
+         && a.has_bl_version == b.has_bl_version;
 }
 
 /// @brief Enum representing the overall state of the system

--- a/sygnal_can_interface/sygnal_can_interface_lib/include/sygnal_can_interface_lib/sygnal_mcm_interface.hpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/include/sygnal_can_interface_lib/sygnal_mcm_interface.hpp
@@ -16,6 +16,7 @@
 #define SYGNAL_CAN_INTERFACE_LIB__SYGNAL_MCM_INTERFACE_HPP_
 
 #include <array>
+#include <optional>
 #include <string>
 
 #include "socketcan_adapter/can_frame.hpp"
@@ -26,6 +27,42 @@ namespace polymath::sygnal
 
 constexpr uint8_t DEFAULT_MCM_BUS_ADDRESS = 1;
 constexpr uint8_t SECONDARY_MCM_BUS_ADDRESS = 2;
+
+/// @brief A major.minor.patch firmware version reported in an MCM Identify response.
+struct SygnalVersion
+{
+  uint16_t major{0};
+  uint16_t minor{0};
+  uint16_t patch{0};
+};
+
+inline bool operator==(const SygnalVersion & a, const SygnalVersion & b)
+{
+  return a.major == b.major && a.minor == b.minor && a.patch == b.patch;
+}
+
+/// @brief Identity and firmware versions of one MCM, assembled from its three IdentifyResponse
+///        frames (Main, AppVersion, BLVersion).
+//         Each frame arrives independently
+///        and the has_* flags mark which parts have been recorded.
+struct McmIdentity
+{
+  uint32_t module_serial_number{0};
+  uint16_t product_id{0};
+  uint8_t module_boot_state{0};
+  SygnalVersion app_version{};
+  SygnalVersion bl_version{};
+  bool has_main{false};
+  bool has_app_version{false};
+  bool has_bl_version{false};
+};
+
+inline bool operator==(const McmIdentity & a, const McmIdentity & b)
+{
+  return a.module_serial_number == b.module_serial_number && a.product_id == b.product_id &&
+         a.module_boot_state == b.module_boot_state && a.app_version == b.app_version && a.bl_version == b.bl_version &&
+         a.has_main == b.has_main && a.has_app_version == b.has_app_version && a.has_bl_version == b.has_bl_version;
+}
 
 /// @brief Enum representing the overall state of the system
 enum class SygnalSystemState : uint8_t
@@ -93,7 +130,23 @@ public:
     return last_heartbeat_timestamp_;
   }
 
+  /// @brief Get the identity assembled from this MCM's IdentifyResponse frames.
+  /// @return std::nullopt until at least one IdentifyResponse frame has been recorded.
+  std::optional<McmIdentity> get_identity() const
+  {
+    if (!mcm_identity_.has_main && !mcm_identity_.has_app_version && !mcm_identity_.has_bl_version) {
+      return std::nullopt;
+    }
+    return mcm_identity_;
+  }
+
   bool parseMcmHeartbeatFrame(const socketcan::CanFrame & frame);
+
+  /// @brief Parse an MCM IdentifyResponse frame (Main / AppVersion / BLVersion)
+  //         addressed to this MCM and record the result.
+  //         Identify frames carry no CRC, so the filtering is done via bus + subsystem.
+  /// @return true if the frame was a matching IdentifyResponse and was recorded.
+  bool parseIdentifyResponseFrame(const socketcan::CanFrame & frame);
 
 private:
   uint8_t subsystem_id_;
@@ -101,6 +154,7 @@ private:
   SygnalSystemState sygnal_mcm_state_;
   std::array<SygnalSystemState, 5> sygnal_interface_states_;
   std::chrono::system_clock::time_point last_heartbeat_timestamp_;
+  McmIdentity mcm_identity_;
 };
 
 }  // namespace polymath::sygnal

--- a/sygnal_can_interface/sygnal_can_interface_lib/src/sygnal_command_interface.cpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/src/sygnal_command_interface.cpp
@@ -18,6 +18,7 @@
 
 #include "sygnal_can_interface_lib/crc8.hpp"
 #include "sygnal_dbc/mcm_control.h"
+#include "sygnal_dbc/mcm_identify.h"
 #include "sygnal_dbc/mcm_relay.h"
 
 namespace polymath::sygnal
@@ -187,6 +188,17 @@ std::optional<polymath::socketcan::CanFrame> SygnalControlInterface::createRelay
   frame.set_len(MCM_RELAY_RELAY_COMMAND_LENGTH);
   frame.set_data(mcm_relay_command_packed_data);
 
+  return frame;
+}
+
+polymath::socketcan::CanFrame SygnalControlInterface::createIdentifyCommandFrame()
+{
+  polymath::socketcan::CanFrame frame;
+  std::array<unsigned char, CAN_MAX_DLC> data;
+  data.fill(0);
+  frame.set_can_id(MCM_IDENTIFY_IDENTIFY_COMMAND_FRAME_ID);
+  frame.set_len(MCM_IDENTIFY_IDENTIFY_COMMAND_LENGTH);
+  frame.set_data(data);
   return frame;
 }
 

--- a/sygnal_can_interface/sygnal_can_interface_lib/src/sygnal_interface_socketcan.cpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/src/sygnal_interface_socketcan.cpp
@@ -106,6 +106,14 @@ bool SygnalInterfaceSocketcan::parse(const socketcan::CanFrame & frame)
     }
   }
 
+  // IdentifyResponse frames (0x601-0x603) carry bus_address + subsystem_id and no CRC; each MCM claims
+  // only its own, mirroring the heartbeat filter.
+  for (auto & mcm : mcms_) {
+    if (mcm.parseIdentifyResponseFrame(frame)) {
+      return true;
+    }
+  }
+
   // Try parsing as a (legacy unified) MCM command response. Safe to run last: every HPO-addressed frame
   // has already been claimed above, so anything reaching this line is either an MCM frame or unrelated.
   auto response = control_interface_.parseCommandResponseFrame(frame);
@@ -375,6 +383,29 @@ std::optional<std::array<bool, HPO_NUM_INTERFACES>> SygnalInterfaceSocketcan::ge
     return std::nullopt;
   }
   return it->get_interface_states();
+}
+
+bool SygnalInterfaceSocketcan::sendIdentifyQuery(std::string & error_message)
+{
+  auto frame = control_interface_.createIdentifyCommandFrame();
+
+  auto err = socketcan_adapter_->send(frame);
+  if (err.has_value()) {
+    error_message += "Failed to send identify query: " + err.value() + "\n";
+    return false;
+  }
+  return true;
+}
+
+std::optional<McmIdentity> SygnalInterfaceSocketcan::get_mcm_identity(uint8_t bus_address, uint8_t subsystem_id) const
+{
+  auto it = std::find_if(mcms_.begin(), mcms_.end(), [bus_address, subsystem_id](const SygnalMcmInterface & m) {
+    return m.get_bus_address() == bus_address && m.get_subsystem_id() == subsystem_id;
+  });
+  if (it == mcms_.end()) {
+    return std::nullopt;
+  }
+  return it->get_identity();
 }
 
 }  // namespace polymath::sygnal

--- a/sygnal_can_interface/sygnal_can_interface_lib/src/sygnal_mcm_interface.cpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/src/sygnal_mcm_interface.cpp
@@ -18,6 +18,7 @@
 
 #include "sygnal_can_interface_lib/crc8.hpp"
 #include "sygnal_dbc/mcm_heartbeat.h"
+#include "sygnal_dbc/mcm_identify.h"
 
 namespace polymath::sygnal
 {
@@ -81,6 +82,68 @@ bool SygnalMcmInterface::parseMcmHeartbeatFrame(const socketcan::CanFrame & fram
   sygnal_interface_states_[4] = SygnalSystemState(unpacked_heartbeat_t.interface4_state);
 
   return true;
+}
+
+bool SygnalMcmInterface::parseIdentifyResponseFrame(const socketcan::CanFrame & frame)
+{
+  auto frame_copy = frame.get_frame();
+
+  switch (frame.get_id()) {
+    case MCM_IDENTIFY_IDENTIFY_RESPONSE_MAIN_FRAME_ID: {
+      mcm_identify_identify_response_main_t unpacked;
+      if (mcm_identify_identify_response_main_init(&unpacked) != 0) {
+        return false;
+      }
+      if (mcm_identify_identify_response_main_unpack(&unpacked, frame_copy.data, frame_copy.len) != 0) {
+        return false;
+      }
+      if (unpacked.bus_address != bus_address_ || unpacked.subsystem_id != subsystem_id_) {
+        return false;
+      }
+      mcm_identity_.module_serial_number = unpacked.module_serial_number;
+      mcm_identity_.product_id = unpacked.product_id;
+      mcm_identity_.module_boot_state = unpacked.module_boot_state;
+      mcm_identity_.has_main = true;
+      return true;
+    }
+
+    case MCM_IDENTIFY_IDENTIFY_RESPONSE_APP_VERSION_FRAME_ID: {
+      mcm_identify_identify_response_app_version_t unpacked;
+      if (mcm_identify_identify_response_app_version_init(&unpacked) != 0) {
+        return false;
+      }
+      if (mcm_identify_identify_response_app_version_unpack(&unpacked, frame_copy.data, frame_copy.len) != 0) {
+        return false;
+      }
+      if (unpacked.bus_address != bus_address_ || unpacked.subsystem_id != subsystem_id_) {
+        return false;
+      }
+      mcm_identity_.app_version = {
+        unpacked.software_version_major, unpacked.software_version_minor, unpacked.software_version_patch};
+      mcm_identity_.has_app_version = true;
+      return true;
+    }
+
+    case MCM_IDENTIFY_IDENTIFY_RESPONSE_BL_VERSION_FRAME_ID: {
+      mcm_identify_identify_response_bl_version_t unpacked;
+      if (mcm_identify_identify_response_bl_version_init(&unpacked) != 0) {
+        return false;
+      }
+      if (mcm_identify_identify_response_bl_version_unpack(&unpacked, frame_copy.data, frame_copy.len) != 0) {
+        return false;
+      }
+      if (unpacked.bus_address != bus_address_ || unpacked.subsystem_id != subsystem_id_) {
+        return false;
+      }
+      mcm_identity_.bl_version = {
+        unpacked.software_version_major, unpacked.software_version_minor, unpacked.software_version_patch};
+      mcm_identity_.has_bl_version = true;
+      return true;
+    }
+
+    default:
+      return false;
+  }
 }
 
 }  // namespace polymath::sygnal

--- a/sygnal_can_interface/sygnal_can_interface_lib/test/sygnal_identify_test.cpp
+++ b/sygnal_can_interface/sygnal_can_interface_lib/test/sygnal_identify_test.cpp
@@ -1,0 +1,159 @@
+// Copyright (c) 2026-present Polymath Robotics, Inc. All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <array>
+
+#include "sygnal_can_interface_lib/sygnal_mcm_interface.hpp"
+
+#if __has_include(<catch2/catch_all.hpp>)
+  #include <catch2/catch_all.hpp>
+#elif __has_include(<catch2/catch.hpp>)
+  #include <catch2/catch.hpp>
+#else
+  #error "Catch2 headers not found. Please install Catch2 (v2 or v3)."
+#endif
+
+#include "socketcan_adapter/can_frame.hpp"
+#include "sygnal_can_interface_lib/sygnal_command_interface.hpp"
+#include "sygnal_dbc/mcm_identify.h"
+
+namespace
+{
+
+polymath::socketcan::CanFrame toFrame(uint32_t can_id, const uint8_t (&buf)[8])
+{
+  polymath::socketcan::CanFrame frame;
+  std::array<unsigned char, CAN_MAX_DLC> data;
+  data.fill(0);
+  for (size_t i = 0; i < 8; ++i) {
+    data[i] = buf[i];
+  }
+  frame.set_can_id(can_id);
+  frame.set_len(8);
+  frame.set_data(data);
+  return frame;
+}
+
+polymath::socketcan::CanFrame mainFrame(uint8_t bus, uint8_t sub, uint8_t boot, uint16_t product, uint32_t serial)
+{
+  mcm_identify_identify_response_main_t m;
+  mcm_identify_identify_response_main_init(&m);
+  m.bus_address = bus;
+  m.subsystem_id = sub;
+  m.module_boot_state = boot;
+  m.product_id = product;
+  m.module_serial_number = serial;
+  uint8_t buf[8] = {0};
+  mcm_identify_identify_response_main_pack(buf, &m, sizeof(buf));
+  return toFrame(MCM_IDENTIFY_IDENTIFY_RESPONSE_MAIN_FRAME_ID, buf);
+}
+
+polymath::socketcan::CanFrame appVersionFrame(uint8_t bus, uint8_t sub, uint16_t major, uint16_t minor, uint16_t patch)
+{
+  mcm_identify_identify_response_app_version_t m;
+  mcm_identify_identify_response_app_version_init(&m);
+  m.bus_address = bus;
+  m.subsystem_id = sub;
+  m.software_version_major = major;
+  m.software_version_minor = minor;
+  m.software_version_patch = patch;
+  uint8_t buf[8] = {0};
+  mcm_identify_identify_response_app_version_pack(buf, &m, sizeof(buf));
+  return toFrame(MCM_IDENTIFY_IDENTIFY_RESPONSE_APP_VERSION_FRAME_ID, buf);
+}
+
+polymath::socketcan::CanFrame blVersionFrame(uint8_t bus, uint8_t sub, uint16_t major, uint16_t minor, uint16_t patch)
+{
+  mcm_identify_identify_response_bl_version_t m;
+  mcm_identify_identify_response_bl_version_init(&m);
+  m.bus_address = bus;
+  m.subsystem_id = sub;
+  m.software_version_major = major;
+  m.software_version_minor = minor;
+  m.software_version_patch = patch;
+  uint8_t buf[8] = {0};
+  mcm_identify_identify_response_bl_version_pack(buf, &m, sizeof(buf));
+  return toFrame(MCM_IDENTIFY_IDENTIFY_RESPONSE_BL_VERSION_FRAME_ID, buf);
+}
+
+}  // namespace
+
+TEST_CASE("get_identity is nullopt before any identify response", "[sygnal_identify]")
+{
+  polymath::sygnal::SygnalMcmInterface interface(polymath::sygnal::DEFAULT_MCM_BUS_ADDRESS, 0);
+  REQUIRE_FALSE(interface.get_identity().has_value());
+}
+
+TEST_CASE("parses IdentifyResponseMain for the matching endpoint", "[sygnal_identify]")
+{
+  polymath::sygnal::SygnalMcmInterface interface(polymath::sygnal::DEFAULT_MCM_BUS_ADDRESS, 0);
+
+  auto frame = mainFrame(polymath::sygnal::DEFAULT_MCM_BUS_ADDRESS, 0, 2, 0x1234, 0xDEADBEEF);
+  REQUIRE(interface.parseIdentifyResponseFrame(frame));
+
+  auto identity = interface.get_identity();
+  REQUIRE(identity.has_value());
+  REQUIRE(identity->has_main);
+  REQUIRE_FALSE(identity->has_app_version);
+  REQUIRE_FALSE(identity->has_bl_version);
+  REQUIRE(identity->module_boot_state == 2);
+  REQUIRE(identity->product_id == 0x1234);
+  REQUIRE(identity->module_serial_number == 0xDEADBEEF);
+}
+
+TEST_CASE("assembles full identity from all three response frames", "[sygnal_identify]")
+{
+  polymath::sygnal::SygnalMcmInterface interface(polymath::sygnal::DEFAULT_MCM_BUS_ADDRESS, 1);
+
+  REQUIRE(interface.parseIdentifyResponseFrame(mainFrame(polymath::sygnal::DEFAULT_MCM_BUS_ADDRESS, 1, 0, 42, 100)));
+  REQUIRE(interface.parseIdentifyResponseFrame(appVersionFrame(polymath::sygnal::DEFAULT_MCM_BUS_ADDRESS, 1, 3, 4, 5)));
+  REQUIRE(interface.parseIdentifyResponseFrame(blVersionFrame(polymath::sygnal::DEFAULT_MCM_BUS_ADDRESS, 1, 6, 7, 8)));
+
+  auto identity = interface.get_identity();
+  REQUIRE(identity.has_value());
+  REQUIRE(identity->has_main);
+  REQUIRE(identity->has_app_version);
+  REQUIRE(identity->has_bl_version);
+  REQUIRE(identity->product_id == 42);
+  REQUIRE(identity->app_version == polymath::sygnal::SygnalVersion{3, 4, 5});
+  REQUIRE(identity->bl_version == polymath::sygnal::SygnalVersion{6, 7, 8});
+}
+
+TEST_CASE("ignores identify responses addressed to a different endpoint", "[sygnal_identify]")
+{
+  polymath::sygnal::SygnalMcmInterface interface(polymath::sygnal::DEFAULT_MCM_BUS_ADDRESS, 0);
+
+  // Wrong subsystem
+  REQUIRE_FALSE(interface.parseIdentifyResponseFrame(mainFrame(polymath::sygnal::DEFAULT_MCM_BUS_ADDRESS, 1, 0, 1, 1)));
+  // Wrong bus address
+  REQUIRE_FALSE(
+    interface.parseIdentifyResponseFrame(mainFrame(polymath::sygnal::SECONDARY_MCM_BUS_ADDRESS, 0, 0, 1, 1)));
+
+  REQUIRE_FALSE(interface.get_identity().has_value());
+}
+
+TEST_CASE("ignores non-identify frames", "[sygnal_identify]")
+{
+  polymath::sygnal::SygnalMcmInterface interface(polymath::sygnal::DEFAULT_MCM_BUS_ADDRESS, 0);
+  uint8_t buf[8] = {0};
+  REQUIRE_FALSE(interface.parseIdentifyResponseFrame(toFrame(0x123, buf)));
+}
+
+TEST_CASE("createIdentifyCommandFrame is a zero-length broadcast", "[sygnal_identify]")
+{
+  polymath::sygnal::SygnalControlInterface control;
+  auto frame = control.createIdentifyCommandFrame();
+  REQUIRE(frame.get_id() == MCM_IDENTIFY_IDENTIFY_COMMAND_FRAME_ID);
+  REQUIRE(frame.get_len() == 0);
+}

--- a/sygnal_can_interface/sygnal_can_interface_ros2/include/sygnal_can_interface_ros2/sygnal_can_interface_node.hpp
+++ b/sygnal_can_interface/sygnal_can_interface_ros2/include/sygnal_can_interface_ros2/sygnal_can_interface_node.hpp
@@ -31,6 +31,8 @@
 #include "socketcan_adapter/socketcan_adapter.hpp"
 #include "sygnal_can_interface_lib/sygnal_interface_socketcan.hpp"
 #include "sygnal_can_msgs/msg/mcm_heartbeat.hpp"
+#include "sygnal_can_msgs/msg/mcm_identity.hpp"
+#include "sygnal_can_msgs/srv/query_identities.hpp"
 #include "sygnal_can_msgs/srv/send_control_command.hpp"
 #include "sygnal_can_msgs/srv/send_relay_command.hpp"
 #include "sygnal_can_msgs/srv/set_control_state.hpp"
@@ -93,6 +95,17 @@ private:
   /// @param msg Incoming control command message
   void controlCommandCallback(const sygnal_can_msgs::msg::ControlCommand::UniquePtr msg);
 
+  /// @brief Service callback to broadcast an identify query and return recorded MCM identities
+  /// @param request Service request
+  /// @param response Service response with success flag and recorded identities
+  void queryIdentitiesCallback(
+    const std::shared_ptr<sygnal_can_msgs::srv::QueryIdentities::Request> request,
+    std::shared_ptr<sygnal_can_msgs::srv::QueryIdentities::Response> response);
+
+  /// @brief Build a McmIdentity ROS message from the library's identity struct
+  sygnal_can_msgs::msg::McmIdentity makeIdentityMsg(
+    uint8_t bus_id, uint8_t subsystem_id, const polymath::sygnal::McmIdentity & identity);
+
   /// @brief Create diagnostics array from Sygnal status
   /// @return Diagnostic array message
   diagnostic_msgs::msg::DiagnosticArray createDiagnosticsMessage();
@@ -112,6 +125,7 @@ private:
   rclcpp::Service<sygnal_can_msgs::srv::SetControlState>::SharedPtr set_control_state_service_;
   rclcpp::Service<sygnal_can_msgs::srv::SendControlCommand>::SharedPtr send_control_command_service_;
   rclcpp::Service<sygnal_can_msgs::srv::SendRelayCommand>::SharedPtr send_relay_command_service_;
+  rclcpp::Service<sygnal_can_msgs::srv::QueryIdentities>::SharedPtr query_identities_service_;
 
   // MCM heartbeat publisher entry
   struct McmHeartbeatEntry
@@ -122,9 +136,19 @@ private:
     std::optional<sygnal_can_msgs::msg::McmHeartbeat> current_state;
   };
 
+  // MCM identity publisher entry
+  struct McmIdentityEntry
+  {
+    uint8_t bus_id;
+    uint8_t subsystem_id;
+    rclcpp_lifecycle::LifecyclePublisher<sygnal_can_msgs::msg::McmIdentity>::SharedPtr publisher;
+    std::optional<polymath::sygnal::McmIdentity> last_published;
+  };
+
   // Publishers
   rclcpp_lifecycle::LifecyclePublisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr diagnostics_pub_;
   std::vector<McmHeartbeatEntry> mcm_heartbeat_entries_;
+  std::vector<McmIdentityEntry> mcm_identity_entries_;
 
   rclcpp::Subscription<sygnal_can_msgs::msg::ControlCommand>::SharedPtr control_command_sub_;
 };

--- a/sygnal_can_interface/sygnal_can_interface_ros2/src/sygnal_can_interface_node.cpp
+++ b/sygnal_can_interface/sygnal_can_interface_ros2/src/sygnal_can_interface_node.cpp
@@ -139,6 +139,19 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Sygnal
       entry.publisher = create_publisher<sygnal_can_msgs::msg::McmHeartbeat>(topic, rclcpp::QoS(10));
     }
 
+    mcm_identity_entries_.reserve(mcm_ids_.size());
+    for (const auto & id : mcm_ids_) {
+      mcm_identity_entries_.push_back({id.bus_id, id.subsystem_id, {}, {}});
+    }
+
+    rclcpp::QoS latched_publisher_qos{rclcpp::QoS(1).transient_local()};
+
+    for (auto & entry : mcm_identity_entries_) {
+      std::string topic =
+        "~/mcm_identity_bus" + std::to_string(entry.bus_id) + "_sub" + std::to_string(entry.subsystem_id);
+      entry.publisher = create_publisher<sygnal_can_msgs::msg::McmIdentity>(topic, latched_publisher_qos);
+    }
+
     // Create services
     set_control_state_service_ = create_service<sygnal_can_msgs::srv::SetControlState>(
       "~/set_control_state",
@@ -152,6 +165,10 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Sygnal
     send_relay_command_service_ = create_service<sygnal_can_msgs::srv::SendRelayCommand>(
       "~/send_relay_command",
       std::bind(&SygnalCanInterfaceNode::sendRelayCommandCallback, this, std::placeholders::_1, std::placeholders::_2));
+
+    query_identities_service_ = create_service<sygnal_can_msgs::srv::QueryIdentities>(
+      "~/query_identities",
+      std::bind(&SygnalCanInterfaceNode::queryIdentitiesCallback, this, std::placeholders::_1, std::placeholders::_2));
 
     // Create timer for publishing
     auto period = std::chrono::duration<double>(1.0 / params_.publish_rate);
@@ -175,11 +192,21 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Sygnal
   for (auto & entry : mcm_heartbeat_entries_) {
     entry.publisher->on_activate();
   }
+  for (auto & entry : mcm_identity_entries_) {
+    entry.publisher->on_activate();
+  }
 
   control_command_sub_ = create_subscription<sygnal_can_msgs::msg::ControlCommand>(
     "~/control_command",
     rclcpp::QoS(10),
     std::bind(&SygnalCanInterfaceNode::controlCommandCallback, this, std::placeholders::_1));
+
+  // Broadcast one identify query to pre-populate identity storage. Responses arrive asynchronously on
+  // the reception thread and are published by the timer as they land.
+  std::string identify_error;
+  if (!sygnal_interface_->sendIdentifyQuery(identify_error)) {
+    RCLCPP_WARN(get_logger(), "Failed to broadcast startup identify query: %s", identify_error.c_str());
+  }
 
   RCLCPP_INFO(get_logger(), "Sygnal CAN Interface node activated");
   return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
@@ -191,6 +218,9 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Sygnal
   // Deactivate publishers
   diagnostics_pub_->on_deactivate();
   for (auto & entry : mcm_heartbeat_entries_) {
+    entry.publisher->on_deactivate();
+  }
+  for (auto & entry : mcm_identity_entries_) {
     entry.publisher->on_deactivate();
   }
 
@@ -206,8 +236,10 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Sygnal
   set_control_state_service_.reset();
   send_control_command_service_.reset();
   send_relay_command_service_.reset();
+  query_identities_service_.reset();
   diagnostics_pub_.reset();
   mcm_heartbeat_entries_.clear();
+  mcm_identity_entries_.clear();
 
   if (socketcan_adapter_) {
     socketcan_adapter_->joinReceptionThread();
@@ -241,6 +273,16 @@ void SygnalCanInterfaceNode::timerCallback()
 
     entry.current_state = msg;
     entry.publisher->publish(msg);
+  }
+
+  // Publish identities on the latched topics, but only when they change.
+  for (auto & entry : mcm_identity_entries_) {
+    auto identity_opt = sygnal_interface_->get_mcm_identity(entry.bus_id, entry.subsystem_id);
+    if (!identity_opt || entry.last_published == identity_opt) {
+      continue;
+    }
+    entry.last_published = identity_opt;
+    entry.publisher->publish(makeIdentityMsg(entry.bus_id, entry.subsystem_id, identity_opt.value()));
   }
 
   // Create and publish diagnostics
@@ -438,6 +480,58 @@ void SygnalCanInterfaceNode::sendRelayCommandCallback(
     response->success = true;
     response->message = "Relay command sent (no reply expected)";
   }
+}
+
+sygnal_can_msgs::msg::McmIdentity SygnalCanInterfaceNode::makeIdentityMsg(
+  uint8_t bus_id, uint8_t subsystem_id, const polymath::sygnal::McmIdentity & identity)
+{
+  sygnal_can_msgs::msg::McmIdentity msg;
+  msg.header.stamp = now();
+  msg.bus_id = bus_id;
+  msg.subsystem_id = subsystem_id;
+  msg.module_serial_number = identity.module_serial_number;
+  msg.product_id = identity.product_id;
+  msg.module_boot_state = identity.module_boot_state;
+  msg.app_version_major = identity.app_version.major;
+  msg.app_version_minor = identity.app_version.minor;
+  msg.app_version_patch = identity.app_version.patch;
+  msg.bl_version_major = identity.bl_version.major;
+  msg.bl_version_minor = identity.bl_version.minor;
+  msg.bl_version_patch = identity.bl_version.patch;
+  msg.has_main = identity.has_main;
+  msg.has_app_version = identity.has_app_version;
+  msg.has_bl_version = identity.has_bl_version;
+  return msg;
+}
+
+void SygnalCanInterfaceNode::queryIdentitiesCallback(
+  const std::shared_ptr<sygnal_can_msgs::srv::QueryIdentities::Request>,
+  std::shared_ptr<sygnal_can_msgs::srv::QueryIdentities::Response> response)
+{
+  RCLCPP_INFO(get_logger(), "Query identities service called - broadcasting identify query");
+
+  std::string error_message;
+  if (!sygnal_interface_->sendIdentifyQuery(error_message)) {
+    response->success = false;
+    response->message = "Failed to broadcast identify query: " + error_message;
+    RCLCPP_WARN(get_logger(), "%s", response->message.c_str());
+    return;
+  }
+
+  // wait one timeout window for devices to answer
+  std::this_thread::sleep_for(std::chrono::milliseconds(params_.timeout_ms));
+
+  for (const auto & id : mcm_ids_) {
+    auto identity_opt = sygnal_interface_->get_mcm_identity(id.bus_id, id.subsystem_id);
+    if (!identity_opt) {
+      continue;
+    }
+    response->identities.push_back(makeIdentityMsg(id.bus_id, id.subsystem_id, identity_opt.value()));
+  }
+
+  response->success = true;
+  response->message = "Identify query complete: " + std::to_string(response->identities.size()) + " MCM(s) responded";
+  RCLCPP_INFO(get_logger(), "%s", response->message.c_str());
 }
 
 diagnostic_msgs::msg::DiagnosticArray SygnalCanInterfaceNode::createDiagnosticsMessage()

--- a/sygnal_can_interface/sygnal_can_interface_ros2/src/sygnal_can_interface_node.cpp
+++ b/sygnal_can_interface/sygnal_can_interface_ros2/src/sygnal_can_interface_node.cpp
@@ -207,10 +207,7 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Sygnal
   send_control_command_service_.reset();
   send_relay_command_service_.reset();
   diagnostics_pub_.reset();
-  for (auto & entry : mcm_heartbeat_entries_) {
-    entry.publisher.reset();
-    entry.current_state.reset();
-  }
+  mcm_heartbeat_entries_.clear();
 
   if (socketcan_adapter_) {
     socketcan_adapter_->joinReceptionThread();

--- a/sygnal_can_interface/sygnal_can_msgs/CMakeLists.txt
+++ b/sygnal_can_interface/sygnal_can_msgs/CMakeLists.txt
@@ -21,6 +21,7 @@ ament_auto_find_build_dependencies()
 set(msg_files
   "msg/McmHeartbeat.msg"
   "msg/ControlCommand.msg"
+  "msg/McmIdentity.msg"
 )
 
 set(srv_files

--- a/sygnal_can_interface/sygnal_can_msgs/CMakeLists.txt
+++ b/sygnal_can_interface/sygnal_can_msgs/CMakeLists.txt
@@ -28,6 +28,7 @@ set(srv_files
   "srv/SetControlState.srv"
   "srv/SendControlCommand.srv"
   "srv/SendRelayCommand.srv"
+  "srv/QueryIdentities.srv"
 )
 
 set(msg_dependencies

--- a/sygnal_can_interface/sygnal_can_msgs/msg/McmIdentity.msg
+++ b/sygnal_can_interface/sygnal_can_msgs/msg/McmIdentity.msg
@@ -1,0 +1,26 @@
+# MCM identity and firmware versions
+std_msgs/Header header
+
+# Endpoint this identity belongs to
+uint8 bus_id
+uint8 subsystem_id
+
+# From IdentifyResponseMain
+uint32 module_serial_number
+uint16 product_id
+uint8 module_boot_state
+
+# Application firmware version
+uint16 app_version_major
+uint16 app_version_minor
+uint16 app_version_patch
+
+# Bootloader firmware version
+uint16 bl_version_major
+uint16 bl_version_minor
+uint16 bl_version_patch
+
+# Which response frames have been received
+bool has_main
+bool has_app_version
+bool has_bl_version

--- a/sygnal_can_interface/sygnal_can_msgs/srv/QueryIdentities.srv
+++ b/sygnal_can_interface/sygnal_can_msgs/srv/QueryIdentities.srv
@@ -1,0 +1,13 @@
+# Service to broadcast an IdentifyCommand and return identities recorded for configured MCMs
+# Request
+---
+# Response
+
+# Success flag - true if the identify query was broadcast successfully
+bool success
+
+# Optional message describing result or error
+string message
+
+# One entry per configured MCM endpoint that has responded
+sygnal_can_msgs/McmIdentity[] identities


### PR DESCRIPTION

Adds support for querying MCM identity and firmware versions over the Identify protocol (`Identify.dbc`), across the library and ROS 2 layers.

On the ROS side, this PR introduces `McmIdentity.msg` and `QueryIdentities.srv`. The `~/query_identities` service broadcasts an `identify` msg, waits for responses to come in and returns identifications for each device.
- Each discovered mcm device identification is also exposed on a per-endpoint latched (transient_local) `~/mcm_identity_bus<b>_sub<s>`, topic, published once on `on_activate` and republished only on change.

Separately, this PR also introduces a fix for MCM _entries_ being reset, but the vector that contains them not being emptied `on_cleanup`, which left the possibility for duplicate publishers to exist if the node went through multiple state transition cycles

Closes https://github.com/polymathrobotics/sygnal/issues/31